### PR TITLE
fix: align TanStack paths with production deploy

### DIFF
--- a/apps/tanstack-start/src/router.tsx
+++ b/apps/tanstack-start/src/router.tsx
@@ -1,10 +1,12 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+const basepath = import.meta.env.DEV ? "/tanstack" : "/";
+
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
-    basepath: "/tanstack",
+    basepath,
     scrollRestoration: true,
     defaultPreload: "intent",
     defaultPreloadStaleTime: 0,

--- a/apps/tanstack-start/vite.config.ts
+++ b/apps/tanstack-start/vite.config.ts
@@ -4,8 +4,8 @@ import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
-export default defineConfig({
-  base: "/tanstack/",
+export default defineConfig(({ command }) => ({
+  base: command === "serve" ? "/tanstack/" : "/",
   resolve: {
     tsconfigPaths: true,
   },
@@ -37,4 +37,4 @@ export default defineConfig({
       "require-in-the-middle",
     ],
   },
-});
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -19632,6 +19632,7 @@
       "name": "@obs-playground/graphql-client",
       "version": "1.0.0",
       "dependencies": {
+        "@datadog/browser-rum": "^6.23.0",
         "@obs-playground/env": "*",
         "@opentelemetry/api": "^1.9.0",
         "zod": "^4.2.1"


### PR DESCRIPTION
## Summary
- serve the standalone TanStack Render app from `/` in production while keeping `/tanstack` for the local proxy
- make the Vite asset base and TanStack router basepath use the same dev versus production split
- keep `https://localhost/tanstack` working without changing the shared proxy setup

## Testing
- `npm run build -w tanstack-start` *(currently fails on unresolved `@obs-playground/graphql-client/browser` import from `apps/tanstack-start/src/routes/testing/client/broken-mutation.tsx`)*