### PR TITLE
fix: restore TanStack preview deploy

### DIFF
--- a/apps/tanstack-start/src/routes/__root.tsx
+++ b/apps/tanstack-start/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
 
-import appCss from "../styles.css?url";
+import "../styles.css";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -9,7 +9,6 @@ export const Route = createRootRoute({
       { name: "viewport", content: "width=device-width, initial-scale=1" },
       { title: "TanStack Start - OTEL Playground" },
     ],
-    links: [{ rel: "stylesheet", href: appCss }],
   }),
   shellComponent: RootDocument,
 });

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,15 +1,27 @@
+function normalizeBaseUrl(base: string): string {
+  const trimmedBase = base.trim().replace(/\/+$/, "");
+
+  if (/^https?:\/\//.test(trimmedBase)) {
+    return trimmedBase;
+  }
+
+  return `http://${trimmedBase}`;
+}
+
 export function getGraphqlUrl(): string {
   if (!process.env.GRAPHQL_BASE_URL) {
     throw new Error("GRAPHQL_BASE_URL environment variable is required");
   }
-  return `${process.env.GRAPHQL_BASE_URL}/graphql`;
+
+  return `${normalizeBaseUrl(process.env.GRAPHQL_BASE_URL)}/graphql`;
 }
 
 export function getExpressUrl(): string {
   if (!process.env.EXPRESS_BASE_URL) {
     throw new Error("EXPRESS_BASE_URL environment variable is required");
   }
-  return process.env.EXPRESS_BASE_URL;
+
+  return normalizeBaseUrl(process.env.EXPRESS_BASE_URL);
 }
 
 // Resolves a client-exposed env var across framework boundaries:
@@ -34,5 +46,6 @@ export function getPublicGraphqlUrl(): string {
       "VITE_GRAPHQL_BASE_URL or NEXT_PUBLIC_GRAPHQL_BASE_URL environment variable is required",
     );
   }
-  return `${base}/graphql`;
+
+  return `${normalizeBaseUrl(base)}/graphql`;
 }

--- a/render.yaml
+++ b/render.yaml
@@ -20,7 +20,7 @@ services:
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       # OTEL Endpoints (fill in your values)
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -54,7 +54,7 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -88,12 +88,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -136,12 +136,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -182,12 +182,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: VITE_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql


### PR DESCRIPTION
## Summary
- switch server-side service URLs in `render.yaml` to Render private-network `hostport` values so preview SSR requests stop going through public `onrender.com` endpoints
- normalize internal `host:port` env values in `packages/env/src/index.ts` so shared URL helpers still produce valid HTTP URLs
- import TanStack global CSS directly in `apps/tanstack-start/src/routes/__root.tsx` so the production stylesheet is emitted and served correctly

## Testing
- `npm run build -w @obs-playground/env`
- `npm run build -w @obs-playground/graphql-client`
- `npm run build -w @obs-playground/otel`
- `npm run build -w tanstack-start`
- served `apps/tanstack-start/.output/server/index.mjs` locally and confirmed `GET /assets/main-Dp9O0bwr.css` returns `200`