### PR TITLE
fix: restore TanStack deploy paths and preview wiring

### DIFF
--- a/apps/tanstack-start/src/router.tsx
+++ b/apps/tanstack-start/src/router.tsx
@@ -1,10 +1,12 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+const basepath = import.meta.env.DEV ? "/tanstack" : "/";
+
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
-    basepath: "/tanstack",
+    basepath,
     scrollRestoration: true,
     defaultPreload: "intent",
     defaultPreloadStaleTime: 0,

--- a/apps/tanstack-start/src/routes/__root.tsx
+++ b/apps/tanstack-start/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
 
-import appCss from "../styles.css?url";
+import "../styles.css";
 
 export const Route = createRootRoute({
   head: () => ({
@@ -9,7 +9,6 @@ export const Route = createRootRoute({
       { name: "viewport", content: "width=device-width, initial-scale=1" },
       { title: "TanStack Start - OTEL Playground" },
     ],
-    links: [{ rel: "stylesheet", href: appCss }],
   }),
   shellComponent: RootDocument,
 });

--- a/apps/tanstack-start/vite.config.ts
+++ b/apps/tanstack-start/vite.config.ts
@@ -4,8 +4,8 @@ import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { nitro } from "nitro/vite";
 
-export default defineConfig({
-  base: "/tanstack/",
+export default defineConfig(({ command }) => ({
+  base: command === "serve" ? "/tanstack/" : "/",
   resolve: {
     tsconfigPaths: true,
   },
@@ -37,4 +37,4 @@ export default defineConfig({
       "require-in-the-middle",
     ],
   },
-});
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -19632,6 +19632,7 @@
       "name": "@obs-playground/graphql-client",
       "version": "1.0.0",
       "dependencies": {
+        "@datadog/browser-rum": "^6.23.0",
         "@obs-playground/env": "*",
         "@opentelemetry/api": "^1.9.0",
         "zod": "^4.2.1"

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -24,22 +24,10 @@ export function getExpressUrl(): string {
   return normalizeBaseUrl(process.env.EXPRESS_BASE_URL);
 }
 
-// Resolves a client-exposed env var across framework boundaries:
-//   - Vite (TanStack Start): VITE_ prefix, exposed on import.meta.env
-//   - Next.js: NEXT_PUBLIC_ prefix, exposed on process.env
-// Callers pass the full key including prefix (e.g. "VITE_GRAPHQL_BASE_URL").
-// Vite is checked first; falls back to process.env for Next.js/Node.
-function getPublicEnv(key: string): string | undefined {
-  const viteVal = String(import.meta.env[key] ?? "");
-  if (viteVal) return viteVal;
-
-  return process.env[key];
-}
-
 export function getPublicGraphqlUrl(): string {
   const base =
-    getPublicEnv("VITE_GRAPHQL_BASE_URL") ??
-    getPublicEnv("NEXT_PUBLIC_GRAPHQL_BASE_URL");
+    import.meta.env?.VITE_GRAPHQL_BASE_URL ??
+    process.env.NEXT_PUBLIC_GRAPHQL_BASE_URL;
 
   if (!base) {
     throw new Error(

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,15 +1,27 @@
+function normalizeBaseUrl(base: string): string {
+  const trimmedBase = base.trim().replace(/\/+$/, "");
+
+  if (/^https?:\/\//.test(trimmedBase)) {
+    return trimmedBase;
+  }
+
+  return `http://${trimmedBase}`;
+}
+
 export function getGraphqlUrl(): string {
   if (!process.env.GRAPHQL_BASE_URL) {
     throw new Error("GRAPHQL_BASE_URL environment variable is required");
   }
-  return `${process.env.GRAPHQL_BASE_URL}/graphql`;
+
+  return `${normalizeBaseUrl(process.env.GRAPHQL_BASE_URL)}/graphql`;
 }
 
 export function getExpressUrl(): string {
   if (!process.env.EXPRESS_BASE_URL) {
     throw new Error("EXPRESS_BASE_URL environment variable is required");
   }
-  return process.env.EXPRESS_BASE_URL;
+
+  return normalizeBaseUrl(process.env.EXPRESS_BASE_URL);
 }
 
 // Resolves a client-exposed env var across framework boundaries:
@@ -34,5 +46,6 @@ export function getPublicGraphqlUrl(): string {
       "VITE_GRAPHQL_BASE_URL or NEXT_PUBLIC_GRAPHQL_BASE_URL environment variable is required",
     );
   }
-  return `${base}/graphql`;
+
+  return `${normalizeBaseUrl(base)}/graphql`;
 }

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -24,10 +24,21 @@ export function getExpressUrl(): string {
   return normalizeBaseUrl(process.env.EXPRESS_BASE_URL);
 }
 
+function getViteGraphqlBaseUrl(): string | undefined {
+  try {
+    const viteGraphqlBaseUrl: unknown = import.meta.env.VITE_GRAPHQL_BASE_URL;
+
+    return typeof viteGraphqlBaseUrl === "string"
+      ? viteGraphqlBaseUrl
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function getPublicGraphqlUrl(): string {
   const base =
-    import.meta.env?.VITE_GRAPHQL_BASE_URL ??
-    process.env.NEXT_PUBLIC_GRAPHQL_BASE_URL;
+    getViteGraphqlBaseUrl() ?? process.env.NEXT_PUBLIC_GRAPHQL_BASE_URL;
 
   if (!base) {
     throw new Error(

--- a/packages/graphql-client/src/index.ts
+++ b/packages/graphql-client/src/index.ts
@@ -33,16 +33,26 @@ export async function graphqlRequest<T>(
   variables?: Record<string, unknown>,
 ): Promise<T> {
   const activeSpan = trace.getActiveSpan();
+  const graphqlUrl = getGraphqlUrl();
 
   try {
-    const response = await fetch(getGraphqlUrl(), {
+    const response = await fetch(graphqlUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, variables }),
     });
 
     if (!response.ok) {
-      throw new Error(`GraphQL request failed: ${response.status}`);
+      const responseText = await response.text().catch(() => "");
+      const responseSnippet = responseText
+        .trim()
+        .replace(/\s+/g, " ")
+        .slice(0, 200);
+      const responseDetails = responseSnippet ? ` - ${responseSnippet}` : "";
+
+      throw new Error(
+        `GraphQL request failed: ${response.status} (${graphqlUrl})${responseDetails}`,
+      );
     }
 
     const json: unknown = await response.json();

--- a/render.yaml
+++ b/render.yaml
@@ -20,7 +20,7 @@ services:
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       # OTEL Endpoints (fill in your values)
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -54,7 +54,7 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -88,12 +88,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -136,12 +136,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -182,12 +182,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          envVarKey: RENDER_EXTERNAL_URL
+          property: hostport
       - key: VITE_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql

--- a/render.yaml
+++ b/render.yaml
@@ -182,7 +182,7 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["VITE_*", "NEXT_PUBLIC_*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", ".output/**"]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- serve the standalone TanStack app from `/` in production while keeping `/tanstack` for the local proxy
- switch SSR service-to-service URLs in `render.yaml` to Render private-network `hostport` values and normalize them in `packages/env`
- import the TanStack global stylesheet directly so the production CSS asset is emitted and served correctly
- sync the workspace lockfile for the merged GraphQL client dependency graph

## Testing
- `npm run build -w @obs-playground/env`
- `npm run build -w @obs-playground/graphql-client`
- `npm run build -w @obs-playground/otel`
- `npm run build -w tanstack-start`
- served `apps/tanstack-start/.output/server/index.mjs` locally and confirmed `GET /assets/main-Dp9O0bwr.css` returns `200`

## Notes
- This replaces the stacked-preview attempt in `#7`, which does not receive a Render preview because it targets `tanstack-css` instead of `main`.