### PR TITLE
fix: restore Render connectivity and dev startup

### DIFF
--- a/apps/nextjs-app/server.ts
+++ b/apps/nextjs-app/server.ts
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 const port = parseInt(process.env.PORT || "3000", 10);
 const dev = process.env.NODE_ENV !== "production";
-const hostname = "localhost";
+const hostname = "0.0.0.0";
 
 const app = next({ dev, hostname, port, dir: __dirname });
 const handle = app.getRequestHandler();

--- a/render.yaml
+++ b/render.yaml
@@ -20,7 +20,7 @@ services:
         fromService:
           name: obs-express
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       # OTEL Endpoints (fill in your values)
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -54,7 +54,7 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
@@ -88,12 +88,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -136,12 +136,12 @@ services:
         fromService:
           name: obs-graphql
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: NEXT_PUBLIC_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -187,7 +187,7 @@ services:
         fromService:
           name: obs-express
           type: web
-          property: hostport
+          envVarKey: RENDER_EXTERNAL_URL
       - key: VITE_GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,6 +7,11 @@
 set -e
 
 TRACING_BACKEND=${1:-otel}
+SHARED_PACKAGES=(
+  "@obs-playground/env"
+  "@obs-playground/otel"
+  "@obs-playground/graphql-client"
+)
 
 # Set up Datadog environment variable if using Datadog backend
 if [ "$TRACING_BACKEND" = "dd" ]; then
@@ -16,6 +21,11 @@ else
   DD_PREFIX=""
 fi
 
+# Build shared packages before starting app servers so their dist outputs exist.
+for package in "${SHARED_PACKAGES[@]}"; do
+  npm run build --workspace="$package"
+done
+
 # Run all services with both Next.js modes
 NEXTJS_NORMAL_CMD="cd apps/nextjs-app && ${DD_PREFIX}PORT=3000 npm run dev"
 NEXTJS_CUSTOM_CMD="cd apps/nextjs-app && ${DD_PREFIX}CUSTOM_SERVER=true PORT=3002 tsx --env-file=.env.local server.ts"
@@ -23,8 +33,9 @@ NEXTJS_CUSTOM_CMD="cd apps/nextjs-app && ${DD_PREFIX}CUSTOM_SERVER=true PORT=300
 TANSTACK_CMD="cd apps/tanstack-start && ${DD_PREFIX}PORT=3100 npm run dev"
 
 npx concurrently \
-  --names "OTEL,GQL-CLIENT,NEXT,CUSTOM,EXPRESS,GRAPHQL,TANSTACK,PROXY" \
-  --prefix-colors "blue,white,cyan,red,magenta,yellow,#ff6600,green" \
+  --names "ENV,OTEL,GQL-CLIENT,NEXT,CUSTOM,EXPRESS,GRAPHQL,TANSTACK,PROXY" \
+  --prefix-colors "white,blue,cyan,green,red,magenta,yellow,#ff6600,#00aa00" \
+  "cd packages/env && npm run dev" \
   "cd packages/otel && npm run dev" \
   "cd packages/graphql-client && npm run dev" \
   "$NEXTJS_NORMAL_CMD" \


### PR DESCRIPTION
## Summary
- bind the custom Next.js server to `0.0.0.0` so the app can accept external traffic in Render deployments
- switch service URL wiring in `render.yaml` to use each upstream service's `RENDER_EXTERNAL_URL`, restoring cross-service connectivity for deployed apps
- build shared workspace packages before startup and watch the env package during local development so app servers start with the generated outputs they depend on

## Testing
- Not run (not requested)