### PR TITLE
fix: correct Datadog RUM instrumentation and TanStack dev proxy routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ NEXT_PUBLIC_SENTRY_DSN=https://your_sentry_key@oYOUR_ORG_ID.ingest.us.sentry.io/
 DATADOG_OTLP_ENDPOINT=http://localhost:4318
 NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=your_datadog_client_token
 NEXT_PUBLIC_DATADOG_APP_ID=your_datadog_application_id
+VITE_DATADOG_CLIENT_TOKEN=your_datadog_client_token
+VITE_DATADOG_APP_ID=your_datadog_application_id
 
 # ClickStack (local HyperDX-based observability)
 # Run locally with: docker run -p 8080:8080 -p 4320:4318 clickhouse/clickstack-all-in-one:latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ certs/
 *.tsbuildinfo
 datadog.yaml
 test-results/
+.tanstack/
+.output/

--- a/apps/nextjs-app/src/instrumentation-client.ts
+++ b/apps/nextjs-app/src/instrumentation-client.ts
@@ -5,18 +5,24 @@ import { captureRouterTransitionStart } from "@sentry/nextjs";
 datadogRum.init({
   applicationId: process.env.NEXT_PUBLIC_DATADOG_APP_ID ?? "",
   clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN ?? "",
-  site: "us5.datadoghq.com",
+  site: "datadoghq.com",
   service: "nextjs-app",
   sessionSampleRate: 100,
   sessionReplaySampleRate: 100,
   defaultPrivacyLevel: "mask-user-input",
   plugins: [reactPlugin({ router: false })],
   traceSampleRate: 100,
+  traceContextInjection: "all",
   propagateTraceBaggage: true,
   trackResources: true,
   trackLongTasks: true,
   trackUserInteractions: true,
-  allowedTracingUrls: ["https://localhost"],
+  allowedTracingUrls: [
+    {
+      match: () => true,
+      propagatorTypes: ["tracecontext", "datadog"],
+    },
+  ],
   allowedGraphQlUrls: [
     {
       match: /\/graphql$/,

--- a/apps/tanstack-start/.env.example
+++ b/apps/tanstack-start/.env.example
@@ -1,0 +1,11 @@
+# Service URLs (server-side, direct connections bypassing proxy)
+GRAPHQL_BASE_URL=http://localhost:4000
+EXPRESS_BASE_URL=http://localhost:3001
+
+# Service URLs (client-side, through HTTPS proxy)
+VITE_GRAPHQL_BASE_URL=https://localhost
+VITE_EXPRESS_BASE_URL=https://localhost
+
+# Datadog RUM
+VITE_DATADOG_CLIENT_TOKEN=your-datadog-token
+VITE_DATADOG_APP_ID=your-datadog-app-id

--- a/apps/tanstack-start/src/client.tsx
+++ b/apps/tanstack-start/src/client.tsx
@@ -6,7 +6,7 @@ import { hydrateRoot } from "react-dom/client";
 datadogRum.init({
   applicationId: String(import.meta.env.VITE_DATADOG_APP_ID ?? ""),
   clientToken: String(import.meta.env.VITE_DATADOG_CLIENT_TOKEN ?? ""),
-  site: "us5.datadoghq.com",
+  site: "datadoghq.com",
   service: "tanstack-start-app",
   sessionSampleRate: 100,
   sessionReplaySampleRate: 100,
@@ -16,7 +16,12 @@ datadogRum.init({
   trackResources: true,
   trackLongTasks: true,
   trackUserInteractions: true,
-  allowedTracingUrls: ["https://localhost"],
+  allowedTracingUrls: [
+    {
+      match: () => true,
+      propagatorTypes: ["tracecontext", "datadog"],
+    },
+  ],
   allowedGraphQlUrls: [
     {
       match: /\/graphql$/,

--- a/dev-proxy.ts
+++ b/dev-proxy.ts
@@ -46,6 +46,9 @@ function setupSharedRoutes(app: Application): void {
       target: "http://localhost:3100",
       changeOrigin: true,
       ws: true,
+      pathRewrite: {
+        "^/": "/tanstack/",
+      },
     }),
   );
 }


### PR DESCRIPTION
## Summary
- Fix Datadog RUM site configuration from `us5.datadoghq.com` to `datadoghq.com` in both Next.js and TanStack Start apps
- Replace simple string-based `allowedTracingUrls` with a match-all function that propagates both `tracecontext` and `datadog` propagator types, enabling distributed trace correlation for all outgoing requests
- Add `traceContextInjection: "all"` to the Next.js RUM config to ensure trace context headers are injected into every request
- Fix TanStack dev proxy routing by adding `pathRewrite` so requests hitting the proxy root are correctly rewritten to `/tanstack/`
- Add missing Datadog RUM environment variable examples for the TanStack Start app (both root and app-specific `.env.example` files)
- Add `.tanstack/` and `.output/` to `.gitignore`

## Testing
- Not run (not requested)