### PR TITLE
feat: add Datadog log instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=your_datadog_client_token
 NEXT_PUBLIC_DATADOG_APP_ID=your_datadog_application_id
 VITE_DATADOG_CLIENT_TOKEN=your_datadog_client_token
 VITE_DATADOG_APP_ID=your_datadog_application_id
+# DD_LOGS_ENABLED=true  # Enable dd-trace log injection (pino → stdout → DD Agent)
 
 # ClickStack (local HyperDX-based observability)
 # Run locally with: docker run -p 8080:8080 -p 4320:4318 clickhouse/clickstack-all-in-one:latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,30 @@ Frontend makes REST calls to Express → Express orchestrates calls to GraphQL �
 - GraphQL: Apollo Server plugin captures GraphQL errors in spans
 - Next.js: Global error boundary (`global-error.tsx`)
 
+## Logging
+
+**Server-side:** All services use a pino-based logger created by `initializeOtel()` and exported from each app's `src/otel.ts`. Trace context injection is handled automatically by the instrumentation layer — either `@opentelemetry/instrumentation-pino` (OTEL mode) or dd-trace's native pino plugin (dd-trace mode).
+
+**Logging Modes (controlled by `DD_LOGS_ENABLED` env var):**
+
+| Mode        | `DD_TRACE_ENABLED` | `DD_LOGS_ENABLED` | Traces   | Log Injection        | Log Transport                  |
+| ----------- | ------------------ | ----------------- | -------- | -------------------- | ------------------------------ |
+| A (default) | unset              | unset             | OTEL     | instrumentation-pino | OTEL LogRecordProcessor → OTLP |
+| B           | unset              | `true`            | OTEL     | instrumentation-pino | pino → stdout → DD Agent       |
+| C           | `true`             | `true`            | dd-trace | dd-trace pino plugin | pino → stdout → DD Agent       |
+
+**Dev script modes:** `bash scripts/dev.sh otel` (Mode A), `bash scripts/dev.sh dd-logs` (Mode B), `bash scripts/dev.sh dd` (Mode C).
+
+**Usage in services:**
+
+```typescript
+import { logger } from "./otel";
+logger.info("Server listening", { port: 3001 });
+logger.error("Request failed", { err });
+```
+
+**Browser-side:** `@datadog/browser-logs` is initialized in the client entry points (`instrumentation-client.ts` for Next.js, `client.tsx` for TanStack Start) alongside Datadog RUM. It forwards all `console.*` calls and uncaught errors to Datadog Logs. The `datadogLogs` API is available for explicit structured logging from client code.
+
 ## Code Conventions
 
 **TypeScript:**
@@ -194,6 +218,7 @@ Frontend makes REST calls to Express → Express orchestrates calls to GraphQL �
 
 - `packages/otel/src/index.ts` - Shared OTEL initialization and configuration
 - `packages/otel/src/exporters.ts` - Multi-backend exporter configuration
+- `packages/otel/src/logger.ts` - Pino logger factory (trace context injected by instrumentation)
 - `packages/otel/src/types.ts` - TypeScript types for OTEL config
 - `apps/nextjs-app/src/otel.ts` - Next.js-specific instrumentation config
 - `apps/express-server/src/otel.ts` - Express-specific instrumentation config

--- a/apps/express-server/src/error-middleware.ts
+++ b/apps/express-server/src/error-middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { logger } from "./otel";
 
 export function errorHandler(
   err: Error,
@@ -8,6 +9,12 @@ export function errorHandler(
   _next: NextFunction,
 ): void {
   const activeSpan = trace.getActiveSpan();
+
+  logger.error("Unhandled error", {
+    err,
+    method: _req.method,
+    path: _req.path,
+  });
 
   activeSpan?.recordException(err);
   activeSpan?.setStatus({

--- a/apps/express-server/src/index.ts
+++ b/apps/express-server/src/index.ts
@@ -1,6 +1,7 @@
-import "./otel";
+import { logger } from "./otel";
 import express from "express";
 import { errorHandler } from "./error-middleware";
+import { requestLogger } from "./request-logger";
 import { responseInstrumentation } from "./response-instrumentation";
 import healthRoutes from "./routes/health";
 import pricingRoutes from "./routes/pricing";
@@ -16,6 +17,7 @@ const app = express();
 const PORT = process.env.PORT ?? 3001;
 
 app.use(express.json());
+app.use(requestLogger);
 app.use(responseInstrumentation);
 
 // Register routes
@@ -32,4 +34,6 @@ app.use(slowRoutes);
 // Error handling middleware - must be last
 app.use(errorHandler);
 
-app.listen(PORT);
+app.listen(PORT, () => {
+  logger.info("Express server listening", { port: PORT });
+});

--- a/apps/express-server/src/otel.ts
+++ b/apps/express-server/src/otel.ts
@@ -1,7 +1,7 @@
 import { initializeOtel } from "@obs-playground/otel";
 import { ExpressLayerType } from "@opentelemetry/instrumentation-express";
 
-initializeOtel({
+export const { logger } = initializeOtel({
   serviceName: "express-server",
   instrumentations: {
     "@opentelemetry/instrumentation-express": {

--- a/apps/express-server/src/request-logger.ts
+++ b/apps/express-server/src/request-logger.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, NextFunction } from "express";
+import { logger } from "./otel";
+
+export function requestLogger(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const start = Date.now();
+
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    const log = {
+      method: req.method,
+      path: req.path,
+      statusCode: res.statusCode,
+      durationMs: duration,
+    };
+
+    if (res.statusCode >= 500) {
+      logger.error("Request failed", log);
+    } else if (res.statusCode >= 400) {
+      logger.warn("Request client error", log);
+    } else {
+      logger.info("Request completed", log);
+    }
+  });
+
+  next();
+}

--- a/apps/express-server/src/routes/batch-nutrition.ts
+++ b/apps/express-server/src/routes/batch-nutrition.ts
@@ -4,6 +4,7 @@ import { graphqlRequest } from "@obs-playground/graphql-client";
 import { ingredientNutrition } from "../data";
 import type { RecipeNutrition, GraphQLRecipe } from "../types";
 import { batchNutritionSchema } from "../schemas";
+import { logger } from "../otel";
 
 const router = Router();
 
@@ -12,6 +13,7 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
   const parsed = batchNutritionSchema.safeParse(req.body);
 
   if (!parsed.success) {
+    logger.warn("Batch nutrition validation failed", { err: parsed.error });
     activeSpan?.recordException(parsed.error);
     return res.status(400).json({ error: parsed.error.issues });
   }
@@ -42,6 +44,10 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => recipeIds.includes(r.id));
+  logger.info("Batch nutrition recipes fetched from GraphQL", {
+    requested: recipeIds.length,
+    found: selectedRecipes.length,
+  });
 
   // Calculate nutrition for each recipe
   const recipeNutritionData: RecipeNutrition[] = selectedRecipes.map(

--- a/apps/express-server/src/routes/meal-plan.ts
+++ b/apps/express-server/src/routes/meal-plan.ts
@@ -3,6 +3,7 @@ import { trace } from "@opentelemetry/api";
 import { graphqlRequest } from "@obs-playground/graphql-client";
 import { ingredientPrices } from "../data";
 import type { GraphQLRecipe } from "../types";
+import { logger } from "../otel";
 
 const router = Router();
 
@@ -42,6 +43,10 @@ router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => idsArray.includes(r.id));
+  logger.info("Meal plan recipes fetched from GraphQL", {
+    requested: idsArray.length,
+    found: selectedRecipes.length,
+  });
 
   // Calculate cost for each recipe
   const recipeCosts = selectedRecipes.map((recipe) => {

--- a/apps/express-server/src/routes/shopping-list.ts
+++ b/apps/express-server/src/routes/shopping-list.ts
@@ -4,6 +4,7 @@ import { graphqlRequest } from "@obs-playground/graphql-client";
 import { ingredientPrices, ingredientInventory } from "../data";
 import type { ShoppingListItem, GraphQLRecipe } from "../types";
 import { shoppingListSchema } from "../schemas";
+import { logger } from "../otel";
 
 const router = Router();
 
@@ -12,6 +13,7 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
   const parsed = shoppingListSchema.safeParse(req.body);
 
   if (!parsed.success) {
+    logger.warn("Shopping list validation failed", { err: parsed.error });
     activeSpan?.recordException(parsed.error);
     return res.status(400).json({ error: parsed.error.issues });
   }
@@ -44,6 +46,10 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => recipeIds.includes(r.id));
+  logger.info("Shopping list recipes fetched from GraphQL", {
+    requested: recipeIds.length,
+    found: selectedRecipes.length,
+  });
 
   activeSpan?.setAttributes({
     "shopping_list.recipes_found": selectedRecipes.length,

--- a/apps/graphql-server/src/index.ts
+++ b/apps/graphql-server/src/index.ts
@@ -1,14 +1,46 @@
-import "./otel.js";
+import { logger } from "./otel.js";
 import { ApolloServer } from "@apollo/server";
+import type { ApolloServerPlugin } from "@apollo/server";
 import { expressMiddleware } from "@as-integrations/express5";
 import express from "express";
 import cors from "cors";
 import { typeDefs } from "./schema/index.js";
 import { resolvers } from "./resolvers/index.js";
 
+const loggingPlugin = {
+  async requestDidStart({ request }) {
+    const operationName = request.operationName ?? "anonymous";
+    logger.info("GraphQL operation started", { operationName });
+
+    return {
+      async didEncounterErrors({ errors }) {
+        for (const err of errors) {
+          logger.error("GraphQL error", {
+            operationName,
+            err,
+            path: err.path,
+            code: err.extensions.code,
+          });
+        }
+      },
+      async willSendResponse({ response }) {
+        const errorCount =
+          response.body.kind === "single"
+            ? (response.body.singleResult.errors?.length ?? 0)
+            : 0;
+        logger.info("GraphQL operation completed", {
+          operationName,
+          errorCount,
+        });
+      },
+    };
+  },
+} satisfies ApolloServerPlugin;
+
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  plugins: [loggingPlugin],
 });
 
 await server.start();
@@ -16,6 +48,32 @@ await server.start();
 const app = express();
 const PORT = +(process.env.PORT || "4000");
 
+app.use((req, res, next) => {
+  const start = Date.now();
+
+  res.on("finish", () => {
+    const durationMs = Date.now() - start;
+    const log = {
+      method: req.method,
+      path: req.path,
+      statusCode: res.statusCode,
+      durationMs,
+    };
+
+    if (res.statusCode >= 500) {
+      logger.error("GraphQL HTTP request failed", log);
+    } else if (res.statusCode >= 400) {
+      logger.warn("GraphQL HTTP request client error", log);
+    } else {
+      logger.info("GraphQL HTTP request completed", log);
+    }
+  });
+
+  next();
+});
+
 app.post("/graphql", cors(), express.json(), expressMiddleware(server));
 
-app.listen(PORT);
+app.listen(PORT, () => {
+  logger.info("GraphQL server listening", { port: PORT });
+});

--- a/apps/graphql-server/src/otel.ts
+++ b/apps/graphql-server/src/otel.ts
@@ -18,7 +18,7 @@ function getExtensions(error: GraphQLError): Record<string, unknown> {
   return error.extensions;
 }
 
-initializeOtel({
+export const { logger } = initializeOtel({
   serviceName: "graphql-server",
   instrumentations: {
     "@opentelemetry/instrumentation-graphql": {

--- a/apps/graphql-server/src/resolvers/queries.ts
+++ b/apps/graphql-server/src/resolvers/queries.ts
@@ -8,10 +8,7 @@ import {
   ingredients,
 } from "../data/index.js";
 import { getOperationSpan } from "../utils/otel.js";
-import {
-  pricesResponseSchema,
-  nutritionResponseSchema,
-} from "../schemas.js";
+import { pricesResponseSchema, nutritionResponseSchema } from "../schemas.js";
 
 export const Query = {
   recipe: (_: unknown, { id }: { id: string }) => {

--- a/apps/graphql-server/src/utils/otel.ts
+++ b/apps/graphql-server/src/utils/otel.ts
@@ -13,13 +13,13 @@ import { context, createContextKey, type Span } from "@opentelemetry/api";
  */
 const OPERATION_SPAN_KEY = createContextKey("graphql.operation.span");
 
-function hasSpanMethods(
-  value: object,
-): value is { setAttribute: unknown; setAttributes: unknown; setStatus: unknown } {
+function hasSpanMethods(value: object): value is {
+  setAttribute: unknown;
+  setAttributes: unknown;
+  setStatus: unknown;
+} {
   return (
-    "setAttribute" in value &&
-    "setAttributes" in value &&
-    "setStatus" in value
+    "setAttribute" in value && "setAttributes" in value && "setStatus" in value
   );
 }
 

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -14,8 +14,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@datadog/browser-rum": "^6.23.0",
-    "@datadog/browser-rum-react": "^6.23.0",
+    "@datadog/browser-logs": "^6.32.0",
+    "@datadog/browser-rum": "^6.32.0",
+    "@datadog/browser-rum-react": "^6.32.0",
     "@obs-playground/env": "*",
     "@obs-playground/graphql-client": "*",
     "@obs-playground/otel": "*",

--- a/apps/nextjs-app/server.ts
+++ b/apps/nextjs-app/server.ts
@@ -1,4 +1,4 @@
-import "./src/otel.ts";
+import { logger } from "./src/otel";
 import express from "express";
 import next from "next";
 import { fileURLToPath } from "node:url";
@@ -21,6 +21,6 @@ app.prepare().then(() => {
   });
 
   server.listen(port, () => {
-    console.log(`> Ready on http://${hostname}:${port}`);
+    logger.info("Next.js custom server ready", { hostname, port });
   });
 });

--- a/apps/nextjs-app/src/app/batch-nutrition/page.tsx
+++ b/apps/nextjs-app/src/app/batch-nutrition/page.tsx
@@ -22,7 +22,9 @@ const errorResponseSchema = z.object({
 
 type BatchNutritionResponse = z.infer<typeof batchNutritionResponseSchema>;
 
-async function getBatchNutrition(recipeIds: string[]): Promise<BatchNutritionResponse> {
+async function getBatchNutrition(
+  recipeIds: string[],
+): Promise<BatchNutritionResponse> {
   const response = await fetch(`${getExpressUrl()}/batch/nutrition`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
+++ b/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
@@ -99,7 +99,9 @@ async function getIngredientNutrition(
     : { calories: 0, protein: 0, fat: 0, carbs: 0 };
 }
 
-async function getIngredientStock(ingredientId: string): Promise<InventoryData> {
+async function getIngredientStock(
+  ingredientId: string,
+): Promise<InventoryData> {
   const response = await fetch(
     `${getExpressUrl()}/inventory/stock/${ingredientId}`,
     {

--- a/apps/nextjs-app/src/instrumentation-client.ts
+++ b/apps/nextjs-app/src/instrumentation-client.ts
@@ -1,6 +1,16 @@
+import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
 import { reactPlugin } from "@datadog/browser-rum-react";
 import { captureRouterTransitionStart } from "@sentry/nextjs";
+
+datadogLogs.init({
+  clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN ?? "",
+  site: "datadoghq.com",
+  service: "nextjs-app",
+  forwardConsoleLogs: "all",
+  forwardErrorsToLogs: true,
+  sessionSampleRate: 100,
+});
 
 datadogRum.init({
   applicationId: process.env.NEXT_PUBLIC_DATADOG_APP_ID ?? "",

--- a/apps/nextjs-app/src/otel.ts
+++ b/apps/nextjs-app/src/otel.ts
@@ -1,6 +1,6 @@
 import { initializeOtel } from "@obs-playground/otel";
 
-initializeOtel({
+export const { logger } = initializeOtel({
   serviceName: "nextjs-app",
   instrumentations: {
     "@opentelemetry/instrumentation-http": {

--- a/apps/tanstack-start/package.json
+++ b/apps/tanstack-start/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@datadog/browser-rum": "^6.23.0",
+    "@datadog/browser-logs": "^6.32.0",
+    "@datadog/browser-rum": "^6.32.0",
     "@obs-playground/env": "*",
     "@obs-playground/graphql-client": "*",
     "@obs-playground/otel": "*",

--- a/apps/tanstack-start/src/client.tsx
+++ b/apps/tanstack-start/src/client.tsx
@@ -1,7 +1,17 @@
+import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
 import { StartClient } from "@tanstack/react-start/client";
 import { StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
+
+datadogLogs.init({
+  clientToken: String(import.meta.env.VITE_DATADOG_CLIENT_TOKEN ?? ""),
+  site: "datadoghq.com",
+  service: "tanstack-start-app",
+  forwardConsoleLogs: "all",
+  forwardErrorsToLogs: true,
+  sessionSampleRate: 100,
+});
 
 datadogRum.init({
   applicationId: String(import.meta.env.VITE_DATADOG_APP_ID ?? ""),

--- a/apps/tanstack-start/src/otel.ts
+++ b/apps/tanstack-start/src/otel.ts
@@ -1,6 +1,6 @@
 import { initializeOtel } from "@obs-playground/otel";
 
-initializeOtel({
+export const { logger } = initializeOtel({
   serviceName: "tanstack-start-app",
   instrumentations: {
     "@opentelemetry/instrumentation-http": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,8 +90,9 @@
     "apps/nextjs-app": {
       "version": "0.1.0",
       "dependencies": {
-        "@datadog/browser-rum": "^6.23.0",
-        "@datadog/browser-rum-react": "^6.23.0",
+        "@datadog/browser-logs": "^6.32.0",
+        "@datadog/browser-rum": "^6.32.0",
+        "@datadog/browser-rum-react": "^6.32.0",
         "@obs-playground/env": "*",
         "@obs-playground/graphql-client": "*",
         "@obs-playground/otel": "*",
@@ -132,7 +133,8 @@
     },
     "apps/tanstack-start": {
       "dependencies": {
-        "@datadog/browser-rum": "^6.23.0",
+        "@datadog/browser-logs": "^6.32.0",
+        "@datadog/browser-rum": "^6.32.0",
         "@obs-playground/env": "*",
         "@obs-playground/graphql-client": "*",
         "@obs-playground/otel": "*",
@@ -932,22 +934,39 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.31.0.tgz",
-      "integrity": "sha512-csH3dhHVO+qFktqUmhjlZyivCsw8B3FLDlmkF+40G7JT2V/qzVGNjWHQ3pMbom726kvmXi+6OzNmXII1ScA5sQ==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.32.0.tgz",
+      "integrity": "sha512-ikok4zYmoZFcOcIlzFFtImgJXUzAKc1j2zQ6JvAMso7L9xs0BmgFPF1E2Kag03PJ6jddB7QJ7ADjiOTwt6hW+Q==",
       "license": "Apache-2.0"
     },
-    "node_modules/@datadog/browser-rum": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.31.0.tgz",
-      "integrity": "sha512-cGBXp4QNEHvYhmFu0e2pbiIb5GZC9RbDPnng//JSCiIuMSBBai48RsLFr2gvM2bdMl3Ivu6rTjCO4AbZDCHfiQ==",
+    "node_modules/@datadog/browser-logs": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-6.32.0.tgz",
+      "integrity": "sha512-xlySe7tA9IjM4yltWMP/5irvCngKMMRjlI6Z/dVMZfVHxeMRWSJRwtpKLt0VjEWAZ5QIxPJngaoM5uXftCN4aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.31.0",
-        "@datadog/browser-rum-core": "6.31.0"
+        "@datadog/browser-core": "6.32.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "6.31.0"
+        "@datadog/browser-rum": "6.32.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-rum": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.32.0.tgz",
+      "integrity": "sha512-frBWGQSbxMmE9nA0A2PF9Y4kHe4MjaFQxSmFrJUCAVEkwQh//Cp1+vW+FoxIJaR14Sah9zIWzIQF3DiuBzMCqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.32.0",
+        "@datadog/browser-rum-core": "6.32.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "6.32.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -956,22 +975,22 @@
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.31.0.tgz",
-      "integrity": "sha512-uPxxBHphtU5/QH1M/PWRwtqFNRPLvuAYTb0WS8PG6pAejZ27a90W3CtVp9A/cWA/xd0lTsTCEgI55ZpN+jPJbw==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.32.0.tgz",
+      "integrity": "sha512-VK1xa4bd8zxkbkkh53yhbiKy0rPqOP+YWcqGHoJguhRuUwY45rBa+iBSCn+MBdPmTI1cbfBjc6hxNuBxWHkN1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.31.0"
+        "@datadog/browser-core": "6.32.0"
       }
     },
     "node_modules/@datadog/browser-rum-react": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-react/-/browser-rum-react-6.31.0.tgz",
-      "integrity": "sha512-gkyL4ae6TiT3rJ0yxVipOtRkItT+e2ig8VsX8ebzmdC2Zy5/gw+lzjJ5qOGIc2whRoihEsUEFskL2L6dxOoPEw==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-react/-/browser-rum-react-6.32.0.tgz",
+      "integrity": "sha512-6kVtP2+M9yEE/XsGgBXGrh7sROBsjAlztVOulcR2rIviqVdcM4RS3osYSAKDbqKLkwabeKNEi8tVCsA4vC/s+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@datadog/browser-core": "6.31.0",
-        "@datadog/browser-rum-core": "6.31.0"
+        "@datadog/browser-core": "6.32.0",
+        "@datadog/browser-rum-core": "6.32.0"
       },
       "peerDependencies": {
         "react": "18 || 19",
@@ -7320,6 +7339,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -11574,6 +11599,15 @@
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -16476,6 +16510,15 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -16839,6 +16882,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
@@ -16993,6 +17073,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -17109,6 +17205,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -17169,6 +17271,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/recast": {
@@ -17590,6 +17701,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -17991,6 +18111,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -18036,6 +18165,15 @@
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
       "license": "(WTFPL OR MIT)",
       "optional": true
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/srvx": {
       "version": "0.11.12",
@@ -18415,6 +18553,15 @@
         "uglify-js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -19632,7 +19779,7 @@
       "name": "@obs-playground/graphql-client",
       "version": "1.0.0",
       "dependencies": {
-        "@datadog/browser-rum": "^6.23.0",
+        "@datadog/browser-rum": "^6.32.0",
         "@obs-playground/env": "*",
         "@opentelemetry/api": "^1.9.0",
         "zod": "^4.2.1"
@@ -19658,13 +19805,27 @@
       "version": "1.0.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.214.0",
         "@opentelemetry/auto-instrumentations-node": "^0.66.0",
-        "dd-trace": "^5.75.0"
+        "dd-trace": "^5.75.0",
+        "pino": "^9"
       },
       "devDependencies": {
         "@types/node": "^20",
         "eslint": "^9.38.0",
         "typescript": "^5"
+      }
+    },
+    "packages/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "packages/otel/node_modules/@types/node": {

--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "@datadog/browser-rum": "^6.23.0",
+    "@datadog/browser-rum": "^6.32.0",
     "@obs-playground/env": "*",
     "@opentelemetry/api": "^1.9.0",
     "zod": "^4.2.1"

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -19,8 +19,10 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.214.0",
     "@opentelemetry/auto-instrumentations-node": "^0.66.0",
-    "dd-trace": "^5.75.0"
+    "dd-trace": "^5.75.0",
+    "pino": "^9"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/otel/src/exporters.ts
+++ b/packages/otel/src/exporters.ts
@@ -8,7 +8,8 @@ import {
 import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
 import {
   BatchLogRecordProcessor,
-  type LogRecordProcessor, ConsoleLogRecordExporter 
+  type LogRecordProcessor,
+  ConsoleLogRecordExporter,
 } from "@opentelemetry/sdk-logs";
 import {
   PeriodicExportingMetricReader,

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -13,6 +13,7 @@ import {
   createLogProcessors,
   createMetricReaders,
 } from "./exporters.js";
+import { createLogger } from "./logger.js";
 import type { OtelConfig, OtelResult } from "./types.js";
 
 export function initializeOtel(config: OtelConfig): OtelResult {
@@ -41,12 +42,13 @@ export function initializeOtel(config: OtelConfig): OtelResult {
       blocklist: [/^\/_/],
     });
 
-    // eslint-disable-next-line no-console
-    console.log(
+    // Create logger after dd-trace init so dd-trace patches pino
+    const logger = createLogger(ddServiceName);
+    logger.info(
       `Datadog native tracer (dd-trace) initialized for service: ${ddServiceName}`,
     );
 
-    return { sdk: ddTracer };
+    return { sdk: ddTracer, logger };
   }
 
   // Standard OpenTelemetry initialization
@@ -88,10 +90,13 @@ export function initializeOtel(config: OtelConfig): OtelResult {
 
   sdk.start();
 
-  // eslint-disable-next-line no-console
-  console.log(`OpenTelemetry initialized for service: ${serviceName}`);
+  // Create logger after sdk.start() so instrumentation-pino patches pino
+  const logger = createLogger(serviceName);
+  logger.info(`OpenTelemetry initialized for service: ${serviceName}`);
 
-  return { sdk };
+  return { sdk, logger };
 }
 
+export { createLogger } from "./logger.js";
+export type { Logger } from "./logger.js";
 export type { OtelConfig, OtelResult } from "./types.js";

--- a/packages/otel/src/logger.ts
+++ b/packages/otel/src/logger.ts
@@ -1,0 +1,148 @@
+import { context } from "@opentelemetry/api";
+import {
+  logs,
+  SeverityNumber,
+  type AnyValue,
+  type AnyValueMap,
+} from "@opentelemetry/api-logs";
+import pino from "pino";
+
+type LogArgs =
+  | [message: string]
+  | [message: string, attributes: Record<string, unknown>];
+
+export type Logger = {
+  debug: (...args: LogArgs) => void;
+  info: (...args: LogArgs) => void;
+  warn: (...args: LogArgs) => void;
+  error: (...args: LogArgs) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function serializeValue(value: unknown): AnyValue {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      cause: serializeValue(value.cause),
+    };
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(serializeValue);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        serializeValue(nestedValue),
+      ]),
+    );
+  }
+
+  return String(value);
+}
+
+function normalizeArgs(args: LogArgs): {
+  body: string;
+  attributes: AnyValueMap;
+  exception?: unknown;
+} {
+  if (args.length === 1) {
+    return { body: args[0], attributes: {} };
+  }
+
+  const [body, attributes] = args;
+
+  return {
+    body,
+    attributes: Object.fromEntries(
+      Object.entries(attributes).map(([key, value]) => [
+        key,
+        serializeValue(value),
+      ]),
+    ),
+    exception: attributes.err,
+  };
+}
+
+function createOtelLogger(serviceName: string): Logger {
+  const otelLogger = logs.getLogger(serviceName);
+
+  const emit = (
+    severityNumber: SeverityNumber,
+    severityText: string,
+    ...args: LogArgs
+  ) => {
+    const { body, attributes, exception } = normalizeArgs(args);
+
+    otelLogger.emit({
+      severityNumber,
+      severityText,
+      body,
+      attributes,
+      exception,
+      context: context.active(),
+    });
+  };
+
+  return {
+    debug: (...args) => emit(SeverityNumber.DEBUG, "debug", ...args),
+    info: (...args) => emit(SeverityNumber.INFO, "info", ...args),
+    warn: (...args) => emit(SeverityNumber.WARN, "warn", ...args),
+    error: (...args) => emit(SeverityNumber.ERROR, "error", ...args),
+  };
+}
+
+function createPinoLogger(serviceName: string): Logger {
+  const pinoLogger = pino({
+    name: serviceName,
+    level: process.env.LOG_LEVEL ?? "info",
+  });
+
+  const callPino = (
+    method: "debug" | "info" | "warn" | "error",
+    ...args: LogArgs
+  ) => {
+    if (args.length === 1) {
+      pinoLogger[method](args[0]);
+      return;
+    }
+
+    pinoLogger[method](args[1], args[0]);
+  };
+
+  return {
+    debug: (...args) => callPino("debug", ...args),
+    info: (...args) => callPino("info", ...args),
+    warn: (...args) => callPino("warn", ...args),
+    error: (...args) => callPino("error", ...args),
+  };
+}
+
+export function createLogger(serviceName: string): Logger {
+  if (process.env.DD_TRACE_ENABLED === "true") {
+    return createPinoLogger(serviceName);
+  }
+
+  return createOtelLogger(serviceName);
+}

--- a/packages/otel/src/types.ts
+++ b/packages/otel/src/types.ts
@@ -1,6 +1,7 @@
 import type { NodeSDK } from "@opentelemetry/sdk-node";
 import type { InstrumentationConfigMap } from "@opentelemetry/auto-instrumentations-node";
 import type { Tracer } from "dd-trace";
+import type { Logger } from "./logger.js";
 
 export type OtelConfig = {
   serviceName: string;
@@ -9,4 +10,5 @@ export type OtelConfig = {
 
 export type OtelResult = {
   sdk: NodeSDK | Tracer;
+  logger: Logger;
 };

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # Development script for running all services
-# Usage: bash scripts/dev.sh [tracing_backend]
-#   tracing_backend: "otel" (OpenTelemetry, default) or "dd" (Datadog)
+# Usage: bash scripts/dev.sh [backend]
+#   backend: "otel" (default) - OTEL traces + OTEL logs
+#            "dd" - dd-trace traces + dd-trace logs
+#            "dd-logs" - OTEL traces + dd-trace log injection (pino → stdout)
 
 set -e
 
@@ -13,10 +15,14 @@ SHARED_PACKAGES=(
   "@obs-playground/graphql-client"
 )
 
-# Set up Datadog environment variable if using Datadog backend
+# Set up environment variables based on backend choice
 if [ "$TRACING_BACKEND" = "dd" ]; then
   export DD_TRACE_ENABLED=true
-  DD_PREFIX="DD_TRACE_ENABLED=true "
+  export DD_LOGS_ENABLED=true
+  DD_PREFIX="DD_TRACE_ENABLED=true DD_LOGS_ENABLED=true "
+elif [ "$TRACING_BACKEND" = "dd-logs" ]; then
+  export DD_LOGS_ENABLED=true
+  DD_PREFIX="DD_LOGS_ENABLED=true "
 else
   DD_PREFIX=""
 fi


### PR DESCRIPTION
## Summary
- add a shared logger in `packages/otel` so server services emit correlated logs in both OpenTelemetry and `dd-trace` modes
- instrument the Express and GraphQL servers with request, startup, and error logging, and initialize Datadog browser logs in the Next.js and TanStack clients
- document the new logging modes and environment flags, including the `dd-logs` development flow

## Testing
- Not run (not requested)