### PR TITLE
fix: run Render OTel services with local Datadog agents

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.opencode
+.turbo
+node_modules
+apps/*/node_modules
+packages/*/node_modules
+apps/nextjs-app/.next
+apps/nextjs-app/.next-custom
+apps/nextjs-app/out
+apps/*/dist
+packages/*/dist
+certs
+npm-debug.log*

--- a/apps/express-server/src/index.ts
+++ b/apps/express-server/src/index.ts
@@ -14,7 +14,8 @@ import errorRoutes from "./routes/error";
 import slowRoutes from "./routes/slow";
 
 const app = express();
-const PORT = process.env.PORT ?? 3001;
+const PORT = +(process.env.PORT ?? 3001);
+const HOST = "0.0.0.0";
 
 app.use(express.json());
 app.use(requestLogger);
@@ -34,6 +35,6 @@ app.use(slowRoutes);
 // Error handling middleware - must be last
 app.use(errorHandler);
 
-app.listen(PORT, () => {
+app.listen(PORT, HOST, () => {
   logger.info("Express server listening", { port: PORT });
 });

--- a/apps/graphql-server/src/index.ts
+++ b/apps/graphql-server/src/index.ts
@@ -47,6 +47,7 @@ await server.start();
 
 const app = express();
 const PORT = +(process.env.PORT || "4000");
+const HOST = "0.0.0.0";
 
 app.use((req, res, next) => {
   const start = Date.now();
@@ -74,6 +75,6 @@ app.use((req, res, next) => {
 
 app.post("/graphql", cors(), express.json(), expressMiddleware(server));
 
-app.listen(PORT, () => {
+app.listen(PORT, HOST, () => {
   logger.info("GraphQL server listening", { port: PORT });
 });

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -30,6 +30,7 @@
     "next": "^16.1.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "tsx": "^4",
     "typescript": "^5",
     "zod": "^4.2.1"
   },
@@ -41,7 +42,6 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^16.1.0",
-    "tailwindcss": "^4",
-    "tsx": "^4"
+    "tailwindcss": "^4"
   }
 }

--- a/deploy/render/app-with-datadog/Dockerfile
+++ b/deploy/render/app-with-datadog/Dockerfile
@@ -24,19 +24,19 @@ FROM datadog/agent:7
 
 WORKDIR /app
 
+RUN mkdir -p /opt/node/bin
+
 ENV DD_AUTOCONFIG_FROM_ENVIRONMENT=false
 ENV DD_APM_ENABLED=true
-ENV DD_APM_NON_LOCAL_TRAFFIC=true
-ENV DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
 ENV DD_PROCESS_AGENT_ENABLED=true
-ENV DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:4318
+ENV DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=127.0.0.1:4318
 ENV DD_LOGS_ENABLED=true
 ENV DD_OTLP_CONFIG_LOGS_ENABLED=true
 ENV DATADOG_OTLP_ENDPOINT=http://127.0.0.1:4318
 ENV HOST_PROC=/proc
-ENV PATH=/app/node_modules/.bin:/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/app/node_modules/.bin:/opt/node/bin:/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-COPY --from=builder /usr/local/ /usr/local/
+COPY --from=builder /usr/local/bin/node /opt/node/bin/node
 COPY --from=builder /app /app
 
 RUN chmod +x \

--- a/deploy/render/app-with-datadog/Dockerfile
+++ b/deploy/render/app-with-datadog/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:24-bookworm-slim AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm ci --include=dev
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM datadog/agent:7
+
+WORKDIR /app
+
+ENV DD_AUTOCONFIG_FROM_ENVIRONMENT=false
+ENV DD_APM_ENABLED=true
+ENV DD_APM_NON_LOCAL_TRAFFIC=true
+ENV DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+ENV DD_PROCESS_AGENT_ENABLED=true
+ENV DD_HOSTNAME=local-agent
+ENV DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:4318
+ENV DD_LOGS_ENABLED=true
+ENV DD_OTLP_CONFIG_LOGS_ENABLED=true
+ENV DATADOG_OTLP_ENDPOINT=http://127.0.0.1:4318
+ENV HOST_PROC=/proc
+ENV PATH=/app/node_modules/.bin:/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+COPY --from=builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=builder /app /app
+
+RUN chmod +x \
+  /app/deploy/render/app-with-datadog/start-service.sh \
+  /app/deploy/render/app-with-datadog/run-app.sh
+
+CMD ["./deploy/render/app-with-datadog/start-service.sh"]

--- a/deploy/render/app-with-datadog/Dockerfile
+++ b/deploy/render/app-with-datadog/Dockerfile
@@ -2,9 +2,21 @@ FROM node:24-bookworm-slim AS builder
 
 WORKDIR /app
 
-COPY . .
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps/express-server/package.json ./apps/express-server/package.json
+COPY apps/graphql-server/package.json ./apps/graphql-server/package.json
+COPY apps/nextjs-app/package.json ./apps/nextjs-app/package.json
+COPY apps/tanstack-start/package.json ./apps/tanstack-start/package.json
+COPY packages/env/package.json ./packages/env/package.json
+COPY packages/graphql-client/package.json ./packages/graphql-client/package.json
+COPY packages/otel/package.json ./packages/otel/package.json
+COPY packages/playwright-tests/package.json ./packages/playwright-tests/package.json
 
 RUN npm ci --include=dev
+
+COPY . .
+
 RUN npm run build
 RUN npm prune --omit=dev
 
@@ -17,7 +29,6 @@ ENV DD_APM_ENABLED=true
 ENV DD_APM_NON_LOCAL_TRAFFIC=true
 ENV DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
 ENV DD_PROCESS_AGENT_ENABLED=true
-ENV DD_HOSTNAME=local-agent
 ENV DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT=0.0.0.0:4318
 ENV DD_LOGS_ENABLED=true
 ENV DD_OTLP_CONFIG_LOGS_ENABLED=true
@@ -25,7 +36,7 @@ ENV DATADOG_OTLP_ENDPOINT=http://127.0.0.1:4318
 ENV HOST_PROC=/proc
 ENV PATH=/app/node_modules/.bin:/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-COPY --from=builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=builder /usr/local/ /usr/local/
 COPY --from=builder /app /app
 
 RUN chmod +x \

--- a/deploy/render/app-with-datadog/run-app.sh
+++ b/deploy/render/app-with-datadog/run-app.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${APP_START_COMMAND:-}" ]]; then
+  echo "APP_START_COMMAND must be set"
+  exit 1
+fi
+
+cd /app
+exec /bin/bash -lc "$APP_START_COMMAND"

--- a/deploy/render/app-with-datadog/run-app.sh
+++ b/deploy/render/app-with-datadog/run-app.sh
@@ -7,4 +7,4 @@ if [[ -z "${APP_START_COMMAND:-}" ]]; then
 fi
 
 cd /app
-exec /bin/bash -lc "$APP_START_COMMAND"
+exec /bin/bash -c "$APP_START_COMMAND"

--- a/deploy/render/app-with-datadog/start-service.sh
+++ b/deploy/render/app-with-datadog/start-service.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 agent_pid=""
 app_pid=""
 
+otlp_ready() {
+  node -e 'const net = require("node:net"); const socket = net.connect({ host: "127.0.0.1", port: 4318 }); socket.on("connect", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 1000);'
+}
+
 cleanup() {
   local exit_code=${1:-0}
 
@@ -23,11 +27,13 @@ cleanup() {
 
 trap 'cleanup 0' INT TERM
 
+: "${DD_HOSTNAME:?DD_HOSTNAME must be set}"
+
 /bin/entrypoint.sh &
 agent_pid=$!
 
 for _ in {1..60}; do
-  if node -e 'const net = require("node:net"); const socket = net.connect({ host: "127.0.0.1", port: 4318 }); socket.on("connect", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 1000);'; then
+  if otlp_ready; then
     break
   fi
 
@@ -39,7 +45,7 @@ for _ in {1..60}; do
   sleep 1
 done
 
-if ! node -e 'const net = require("node:net"); const socket = net.connect({ host: "127.0.0.1", port: 4318 }); socket.on("connect", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 1000);'; then
+if ! otlp_ready; then
   echo "Timed out waiting for Datadog OTLP HTTP endpoint on 127.0.0.1:4318"
   cleanup 1
 fi

--- a/deploy/render/app-with-datadog/start-service.sh
+++ b/deploy/render/app-with-datadog/start-service.sh
@@ -10,14 +10,26 @@ otlp_ready() {
 
 cleanup() {
   local exit_code=${1:-0}
+  local deadline=$(( $(date +%s) + 10 ))
 
-  if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
-    kill "$app_pid" 2>/dev/null || true
-  fi
+  for pid in "$app_pid" "$agent_pid"; do
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
 
-  if [[ -n "$agent_pid" ]] && kill -0 "$agent_pid" 2>/dev/null; then
-    kill "$agent_pid" 2>/dev/null || true
-  fi
+  for pid in "$app_pid" "$agent_pid"; do
+    [[ -z "$pid" ]] && continue
+
+    while kill -0 "$pid" 2>/dev/null; do
+      if (( $(date +%s) >= deadline )); then
+        kill -9 "$pid" 2>/dev/null || true
+        break
+      fi
+
+      sleep 0.2
+    done
+  done
 
   wait "$app_pid" 2>/dev/null || true
   wait "$agent_pid" 2>/dev/null || true

--- a/deploy/render/app-with-datadog/start-service.sh
+++ b/deploy/render/app-with-datadog/start-service.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+agent_pid=""
+app_pid=""
+
+cleanup() {
+  local exit_code=${1:-0}
+
+  if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+    kill "$app_pid" 2>/dev/null || true
+  fi
+
+  if [[ -n "$agent_pid" ]] && kill -0 "$agent_pid" 2>/dev/null; then
+    kill "$agent_pid" 2>/dev/null || true
+  fi
+
+  wait "$app_pid" 2>/dev/null || true
+  wait "$agent_pid" 2>/dev/null || true
+
+  exit "$exit_code"
+}
+
+trap 'cleanup 0' INT TERM
+
+/bin/entrypoint.sh &
+agent_pid=$!
+
+for _ in {1..60}; do
+  if node -e 'const net = require("node:net"); const socket = net.connect({ host: "127.0.0.1", port: 4318 }); socket.on("connect", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 1000);'; then
+    break
+  fi
+
+  if ! kill -0 "$agent_pid" 2>/dev/null; then
+    echo "Datadog Agent exited before OTLP became ready"
+    cleanup 1
+  fi
+
+  sleep 1
+done
+
+if ! node -e 'const net = require("node:net"); const socket = net.connect({ host: "127.0.0.1", port: 4318 }); socket.on("connect", () => { socket.end(); process.exit(0); }); socket.on("error", () => process.exit(1)); setTimeout(() => process.exit(1), 1000);'; then
+  echo "Timed out waiting for Datadog OTLP HTTP endpoint on 127.0.0.1:4318"
+  cleanup 1
+fi
+
+./deploy/render/app-with-datadog/run-app.sh &
+app_pid=$!
+
+set +e
+wait -n "$agent_pid" "$app_pid"
+exit_code=$?
+set -e
+
+if ! kill -0 "$agent_pid" 2>/dev/null; then
+  echo "Datadog Agent exited"
+fi
+
+if ! kill -0 "$app_pid" 2>/dev/null; then
+  echo "App process exited"
+fi
+
+cleanup "$exit_code"

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "next": "^16.1.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "tsx": "^4",
         "typescript": "^5",
         "zod": "^4.2.1"
       },
@@ -117,8 +118,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "^16.1.0",
-        "tailwindcss": "^4",
-        "tsx": "^4"
+        "tailwindcss": "^4"
       }
     },
     "apps/nextjs-app/node_modules/@types/node": {

--- a/render.yaml
+++ b/render.yaml
@@ -1,27 +1,30 @@
 services:
-  # GraphQL Server
   - type: web
     name: obs-graphql
-    runtime: node
+    runtime: docker
     plan: free
-    # No rootDir - build from repo root for workspace dependencies
-    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
-    startCommand: node apps/graphql-server/dist/index.js
+    dockerfilePath: ./deploy/render/app-with-datadog/Dockerfile
+    dockerContext: .
     previews:
       generation: automatic
     envVars:
-      - key: NODE_VERSION
-        value: "24"
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
+      - key: APP_START_COMMAND
+        value: node apps/graphql-server/dist/index.js
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_SITE
+        value: datadoghq.com
+      - key: DD_HOSTNAME
+        value: obs-graphql
       - key: EXPRESS_BASE_URL
         fromService:
           name: obs-express
           type: web
           envVarKey: RENDER_EXTERNAL_URL
-      # OTEL Endpoints (fill in your values)
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
       - key: GRAFANA_OTLP_ENDPOINT
@@ -31,31 +34,41 @@ services:
       - fromGroup: obs-playground
     buildFilter:
       paths:
+        - package.json
+        - package-lock.json
+        - turbo.json
+        - patches/**
+        - .dockerignore
+        - deploy/render/app-with-datadog/**
         - apps/graphql-server/**
         - packages/**
 
-  # Express Server
   - type: web
     name: obs-express
-    runtime: node
+    runtime: docker
     plan: free
-    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
-    startCommand: node apps/express-server/dist/index.js
+    dockerfilePath: ./deploy/render/app-with-datadog/Dockerfile
+    dockerContext: .
     previews:
       generation: automatic
     envVars:
-      - key: NODE_VERSION
-        value: "24"
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
+      - key: APP_START_COMMAND
+        value: node apps/express-server/dist/index.js
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_SITE
+        value: datadoghq.com
+      - key: DD_HOSTNAME
+        value: obs-express
       - key: GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
           type: web
           envVarKey: RENDER_EXTERNAL_URL
-      # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
       - key: GRAFANA_OTLP_ENDPOINT
@@ -65,25 +78,36 @@ services:
       - fromGroup: obs-playground
     buildFilter:
       paths:
+        - package.json
+        - package-lock.json
+        - turbo.json
+        - patches/**
+        - .dockerignore
+        - deploy/render/app-with-datadog/**
         - apps/express-server/**
         - packages/**
 
-  # Next.js App
   - type: web
     name: obs-nextjs
-    runtime: node
+    runtime: docker
     plan: free
-    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
-    startCommand: npm run start --workspace=apps/nextjs-app
+    dockerfilePath: ./deploy/render/app-with-datadog/Dockerfile
+    dockerContext: .
     previews:
       generation: automatic
     envVars:
-      - key: NODE_VERSION
-        value: "24"
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
+      - key: APP_START_COMMAND
+        value: next start --hostname 0.0.0.0 --port $PORT
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_SITE
+        value: datadoghq.com
+      - key: DD_HOSTNAME
+        value: obs-nextjs
       - key: GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -99,7 +123,6 @@ services:
           name: obs-graphql
           type: web
           envVarKey: RENDER_EXTERNAL_URL
-      # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
       - key: GRAFANA_OTLP_ENDPOINT
@@ -111,27 +134,38 @@ services:
       - fromGroup: obs-playground
     buildFilter:
       paths:
+        - package.json
+        - package-lock.json
+        - turbo.json
+        - patches/**
+        - .dockerignore
+        - deploy/render/app-with-datadog/**
         - apps/nextjs-app/**
         - packages/**
 
-  # Next.js App (Custom Server)
   - type: web
     name: obs-nextjs-custom
-    runtime: node
+    runtime: docker
     plan: free
-    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
-    startCommand: node apps/nextjs-app/server.ts
+    dockerfilePath: ./deploy/render/app-with-datadog/Dockerfile
+    dockerContext: .
     previews:
       generation: automatic
     envVars:
-      - key: NODE_VERSION
-        value: "24"
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
       - key: CUSTOM_SERVER
         value: "true"
+      - key: APP_START_COMMAND
+        value: node apps/nextjs-app/server.ts
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_SITE
+        value: datadoghq.com
+      - key: DD_HOSTNAME
+        value: obs-nextjs-custom
       - key: GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -147,7 +181,6 @@ services:
           name: obs-graphql
           type: web
           envVarKey: RENDER_EXTERNAL_URL
-      # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
       - key: GRAFANA_OTLP_ENDPOINT
@@ -159,25 +192,36 @@ services:
       - fromGroup: obs-playground
     buildFilter:
       paths:
+        - package.json
+        - package-lock.json
+        - turbo.json
+        - patches/**
+        - .dockerignore
+        - deploy/render/app-with-datadog/**
         - apps/nextjs-app/**
         - packages/**
 
-  # TanStack Start App
   - type: web
     name: obs-tanstack
-    runtime: node
+    runtime: docker
     plan: free
-    buildCommand: npm ci --include=dev && npm run build && npm prune --omit=dev
-    startCommand: node apps/tanstack-start/.output/server/index.mjs
+    dockerfilePath: ./deploy/render/app-with-datadog/Dockerfile
+    dockerContext: .
     previews:
       generation: automatic
     envVars:
-      - key: NODE_VERSION
-        value: "24"
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
+      - key: APP_START_COMMAND
+        value: node apps/tanstack-start/.output/server/index.mjs
+      - key: DD_API_KEY
+        sync: false
+      - key: DD_SITE
+        value: datadoghq.com
+      - key: DD_HOSTNAME
+        value: obs-tanstack
       - key: GRAPHQL_BASE_URL
         fromService:
           name: obs-graphql
@@ -193,7 +237,6 @@ services:
           name: obs-graphql
           type: web
           envVarKey: RENDER_EXTERNAL_URL
-      # OTEL Endpoints
       - key: HONEYCOMB_ENDPOINT
         value: https://api.honeycomb.io
       - key: GRAFANA_OTLP_ENDPOINT
@@ -203,5 +246,11 @@ services:
       - fromGroup: obs-playground
     buildFilter:
       paths:
+        - package.json
+        - package-lock.json
+        - turbo.json
+        - patches/**
+        - .dockerignore
+        - deploy/render/app-with-datadog/**
         - apps/tanstack-start/**
         - packages/**

--- a/render.yaml
+++ b/render.yaml
@@ -159,7 +159,7 @@ services:
       - key: CUSTOM_SERVER
         value: "true"
       - key: APP_START_COMMAND
-        value: node apps/nextjs-app/server.ts
+        value: tsx apps/nextjs-app/server.ts
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE


### PR DESCRIPTION
## Summary
- move the five Render app services from the native Node runtime to a shared Docker image that starts a local Datadog Agent alongside each app process
- keep the existing OpenTelemetry exporter path and point each service at its in-container OTLP HTTP endpoint while preserving current inter-service URL wiring
- make the GraphQL and Express servers bind explicitly to `0.0.0.0` and add shared startup scripts plus Docker build context filtering for the new deploy path

## Verification
- `npm run build`
- `render blueprints validate render.yaml --workspace tea-d541m23e5dus73b8tn00`
- built `deploy/render/app-with-datadog/Dockerfile` locally and smoke-tested the GraphQL service path with the Datadog Agent running in the same container