### PR TITLE
Add single-VM deploy and isolated preview stacks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.opencode
+node_modules
+apps/*/node_modules
+packages/*/node_modules
+apps/*/.next
+apps/*/dist
+apps/*/.output
+packages/*/dist
+coverage
+playwright-report
+test-results
+tmp
+certs

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ NEXT_PUBLIC_SENTRY_DSN=https://your_sentry_key@oYOUR_ORG_ID.ingest.us.sentry.io/
 # Datadog
 # Local Datadog agent - no API key required (agent handles authentication)
 DATADOG_OTLP_ENDPOINT=http://localhost:4318
+DD_API_KEY=your_datadog_api_key_here
+DD_SITE=datadoghq.com
 NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=your_datadog_client_token
 NEXT_PUBLIC_DATADOG_APP_ID=your_datadog_application_id
 VITE_DATADOG_CLIENT_TOKEN=your_datadog_client_token
@@ -34,8 +36,13 @@ VITE_DATADOG_APP_ID=your_datadog_application_id
 NEXT_PUBLIC_STATSIG_CLIENT_KEY=client-your_statsig_client_key_here
 
 # Service URLs (default values for local development)
-# All *_BASE_URL vars contain base URL only - code appends paths
+# All *_BASE_URL vars contain base URL only - code appends paths.
+# Browser GraphQL can also fall back to the current origin in preview deployments.
 GRAPHQL_BASE_URL=http://localhost:4000
 EXPRESS_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_GRAPHQL_BASE_URL=https://localhost
 VITE_GRAPHQL_BASE_URL=https://localhost
+
+# Deployment
+DEPLOY_BASE_DOMAIN=example.com
+ACME_EMAIL=ops@example.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,11 @@ permissions:
   contents: read
   packages: write
 
+env:
+  TF_CLOUD_ORGANIZATION: ${{ vars.TF_CLOUD_ORGANIZATION }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_WORKSPACE_INFRA: ${{ vars.TF_WORKSPACE_INFRA }}
+
 jobs:
   deploy:
     if: |
@@ -63,9 +68,34 @@ jobs:
             --build-arg VITE_DATADOG_APP_ID .
           docker push "$IMAGE_PREFIX/tanstack:$IMAGE_TAG"
 
+      - name: Read deploy host from HCP Terraform
+        uses: hashicorp/tfc-workflows-github/actions/workspace-output@v1.3.2
+        id: infra-outputs
+        with:
+          workspace: ${{ env.TF_WORKSPACE_INFRA }}
+
+      - name: Capture deploy connection settings
+        env:
+          INFRA_OUTPUTS_JSON: ${{ steps.infra-outputs.outputs.outputs }}
+        run: |
+          DEPLOY_HOST=$(jq -r '.[] | select(.attributes.name == "instance_main_ip") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+          DEPLOY_USER=$(jq -r '.[] | select(.attributes.name == "deploy_user") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+
+          if [ -z "$DEPLOY_HOST" ] || [ "$DEPLOY_HOST" = "null" ]; then
+            echo "Missing instance_main_ip output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          if [ -z "$DEPLOY_USER" ] || [ "$DEPLOY_USER" = "null" ]; then
+            echo "Missing deploy_user output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+          echo "DEPLOY_USER=$DEPLOY_USER" >> "$GITHUB_ENV"
+
       - name: Configure SSH
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           install -m 700 -d ~/.ssh
@@ -74,16 +104,11 @@ jobs:
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
 
       - name: Sync deployment artifacts to VM
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
 
       - name: Deploy main stack
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_BASE_DOMAIN: ${{ secrets.DEPLOY_BASE_DOMAIN }}
           ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,140 @@
+name: Deploy Main Stack
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push application images
+        env:
+          IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/obs-playground
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_STATSIG_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STATSIG_CLIENT_KEY }}
+          NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN }}
+          NEXT_PUBLIC_DATADOG_APP_ID: ${{ secrets.NEXT_PUBLIC_DATADOG_APP_ID }}
+          VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
+          VITE_DATADOG_APP_ID: ${{ secrets.VITE_DATADOG_APP_ID }}
+        run: |
+          docker build -f apps/nextjs-app/Dockerfile -t "$IMAGE_PREFIX/nextjs:$IMAGE_TAG" \
+            --build-arg NEXT_PUBLIC_SENTRY_DSN \
+            --build-arg NEXT_PUBLIC_STATSIG_CLIENT_KEY \
+            --build-arg NEXT_PUBLIC_DATADOG_CLIENT_TOKEN \
+            --build-arg NEXT_PUBLIC_DATADOG_APP_ID .
+          docker push "$IMAGE_PREFIX/nextjs:$IMAGE_TAG"
+
+          docker build -f apps/express-server/Dockerfile -t "$IMAGE_PREFIX/express:$IMAGE_TAG" .
+          docker push "$IMAGE_PREFIX/express:$IMAGE_TAG"
+
+          docker build -f apps/graphql-server/Dockerfile -t "$IMAGE_PREFIX/graphql:$IMAGE_TAG" .
+          docker push "$IMAGE_PREFIX/graphql:$IMAGE_TAG"
+
+          docker build -f apps/tanstack-start/Dockerfile -t "$IMAGE_PREFIX/tanstack:$IMAGE_TAG" \
+            --build-arg VITE_DATADOG_CLIENT_TOKEN \
+            --build-arg VITE_DATADOG_APP_ID .
+          docker push "$IMAGE_PREFIX/tanstack:$IMAGE_TAG"
+
+      - name: Configure SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync deployment artifacts to VM
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
+
+      - name: Deploy main stack
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_BASE_DOMAIN: ${{ secrets.DEPLOY_BASE_DOMAIN }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SITE: ${{ secrets.DD_SITE }}
+          HONEYCOMB_ENDPOINT: ${{ secrets.HONEYCOMB_ENDPOINT }}
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+          GRAFANA_OTLP_ENDPOINT: ${{ secrets.GRAFANA_OTLP_ENDPOINT }}
+          GRAFANA_OTLP_AUTH: ${{ secrets.GRAFANA_OTLP_AUTH }}
+          SENTRY_OTLP_ENDPOINT: ${{ secrets.SENTRY_OTLP_ENDPOINT }}
+          SENTRY_AUTH: ${{ secrets.SENTRY_AUTH }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_STATSIG_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STATSIG_CLIENT_KEY }}
+          NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN }}
+          NEXT_PUBLIC_DATADOG_APP_ID: ${{ secrets.NEXT_PUBLIC_DATADOG_APP_ID }}
+          VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
+          VITE_DATADOG_APP_ID: ${{ secrets.VITE_DATADOG_APP_ID }}
+          IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/obs-playground
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "echo '$GHCR_TOKEN' | docker login ghcr.io -u '$GHCR_USER' --password-stdin && \
+            cd /srv/obs/repo && chmod +x scripts/*.sh && \
+            ACME_EMAIL='$ACME_EMAIL' \
+            STACK_NAME='obs-main' \
+            STACK_ENV='production' \
+            STACK_VERSION='$IMAGE_TAG' \
+            STACK_ROUTER_PORT='20000' \
+            PREVIEW_ID='main' \
+            NEXT_HOST='app.$DEPLOY_BASE_DOMAIN' \
+            CUSTOM_HOST='custom.$DEPLOY_BASE_DOMAIN' \
+            TANSTACK_HOST='tanstack.$DEPLOY_BASE_DOMAIN' \
+            OBS_NEXTJS_IMAGE='$IMAGE_PREFIX/nextjs:$IMAGE_TAG' \
+            OBS_EXPRESS_IMAGE='$IMAGE_PREFIX/express:$IMAGE_TAG' \
+            OBS_GRAPHQL_IMAGE='$IMAGE_PREFIX/graphql:$IMAGE_TAG' \
+            OBS_TANSTACK_IMAGE='$IMAGE_PREFIX/tanstack:$IMAGE_TAG' \
+            DD_API_KEY='$DD_API_KEY' \
+            DD_SITE='$DD_SITE' \
+            HONEYCOMB_ENDPOINT='$HONEYCOMB_ENDPOINT' \
+            HONEYCOMB_API_KEY='$HONEYCOMB_API_KEY' \
+            GRAFANA_OTLP_ENDPOINT='$GRAFANA_OTLP_ENDPOINT' \
+            GRAFANA_OTLP_AUTH='$GRAFANA_OTLP_AUTH' \
+            SENTRY_OTLP_ENDPOINT='$SENTRY_OTLP_ENDPOINT' \
+            SENTRY_AUTH='$SENTRY_AUTH' \
+            SENTRY_AUTH_TOKEN='$SENTRY_AUTH_TOKEN' \
+            NEXT_PUBLIC_SENTRY_DSN='$NEXT_PUBLIC_SENTRY_DSN' \
+            NEXT_PUBLIC_STATSIG_CLIENT_KEY='$NEXT_PUBLIC_STATSIG_CLIENT_KEY' \
+            NEXT_PUBLIC_DATADOG_CLIENT_TOKEN='$NEXT_PUBLIC_DATADOG_CLIENT_TOKEN' \
+            NEXT_PUBLIC_DATADOG_APP_ID='$NEXT_PUBLIC_DATADOG_APP_ID' \
+            VITE_DATADOG_CLIENT_TOKEN='$VITE_DATADOG_CLIENT_TOKEN' \
+            VITE_DATADOG_APP_ID='$VITE_DATADOG_APP_ID' \
+            bash scripts/deploy-stack.sh"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,185 @@
+name: Preview Environments
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push preview images
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          IMAGE_TAG: pr-${{ github.event.workflow_run.pull_requests[0].number }}-${{ github.event.workflow_run.head_sha }}
+          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/obs-playground
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_STATSIG_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STATSIG_CLIENT_KEY }}
+          NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN }}
+          NEXT_PUBLIC_DATADOG_APP_ID: ${{ secrets.NEXT_PUBLIC_DATADOG_APP_ID }}
+          VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
+          VITE_DATADOG_APP_ID: ${{ secrets.VITE_DATADOG_APP_ID }}
+        run: |
+          docker build -f apps/nextjs-app/Dockerfile -t "$IMAGE_PREFIX/nextjs:$IMAGE_TAG" \
+            --build-arg NEXT_PUBLIC_SENTRY_DSN \
+            --build-arg NEXT_PUBLIC_STATSIG_CLIENT_KEY \
+            --build-arg NEXT_PUBLIC_DATADOG_CLIENT_TOKEN \
+            --build-arg NEXT_PUBLIC_DATADOG_APP_ID .
+          docker push "$IMAGE_PREFIX/nextjs:$IMAGE_TAG"
+
+          docker build -f apps/express-server/Dockerfile -t "$IMAGE_PREFIX/express:$IMAGE_TAG" .
+          docker push "$IMAGE_PREFIX/express:$IMAGE_TAG"
+
+          docker build -f apps/graphql-server/Dockerfile -t "$IMAGE_PREFIX/graphql:$IMAGE_TAG" .
+          docker push "$IMAGE_PREFIX/graphql:$IMAGE_TAG"
+
+          docker build -f apps/tanstack-start/Dockerfile -t "$IMAGE_PREFIX/tanstack:$IMAGE_TAG" \
+            --build-arg VITE_DATADOG_CLIENT_TOKEN \
+            --build-arg VITE_DATADOG_APP_ID .
+          docker push "$IMAGE_PREFIX/tanstack:$IMAGE_TAG"
+
+      - name: Configure SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync deployment artifacts to VM
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
+
+      - name: Deploy preview stack
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_BASE_DOMAIN: ${{ secrets.DEPLOY_BASE_DOMAIN }}
+          ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SITE: ${{ secrets.DD_SITE }}
+          HONEYCOMB_ENDPOINT: ${{ secrets.HONEYCOMB_ENDPOINT }}
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+          GRAFANA_OTLP_ENDPOINT: ${{ secrets.GRAFANA_OTLP_ENDPOINT }}
+          GRAFANA_OTLP_AUTH: ${{ secrets.GRAFANA_OTLP_AUTH }}
+          SENTRY_OTLP_ENDPOINT: ${{ secrets.SENTRY_OTLP_ENDPOINT }}
+          SENTRY_AUTH: ${{ secrets.SENTRY_AUTH }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+          NEXT_PUBLIC_STATSIG_CLIENT_KEY: ${{ secrets.NEXT_PUBLIC_STATSIG_CLIENT_KEY }}
+          NEXT_PUBLIC_DATADOG_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN }}
+          NEXT_PUBLIC_DATADOG_APP_ID: ${{ secrets.NEXT_PUBLIC_DATADOG_APP_ID }}
+          VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
+          VITE_DATADOG_APP_ID: ${{ secrets.VITE_DATADOG_APP_ID }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          IMAGE_TAG: pr-${{ github.event.workflow_run.pull_requests[0].number }}-${{ github.event.workflow_run.head_sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/obs-playground
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "echo '$GHCR_TOKEN' | docker login ghcr.io -u '$GHCR_USER' --password-stdin && \
+            cd /srv/obs/repo && chmod +x scripts/*.sh && \
+            PR_NUMBER='$PR_NUMBER' \
+            BASE_DOMAIN='$DEPLOY_BASE_DOMAIN' \
+            IMAGE_TAG='$IMAGE_TAG' \
+            ACME_EMAIL='$ACME_EMAIL' \
+            OBS_NEXTJS_IMAGE='$IMAGE_PREFIX/nextjs:$IMAGE_TAG' \
+            OBS_EXPRESS_IMAGE='$IMAGE_PREFIX/express:$IMAGE_TAG' \
+            OBS_GRAPHQL_IMAGE='$IMAGE_PREFIX/graphql:$IMAGE_TAG' \
+            OBS_TANSTACK_IMAGE='$IMAGE_PREFIX/tanstack:$IMAGE_TAG' \
+            DD_API_KEY='$DD_API_KEY' \
+            DD_SITE='$DD_SITE' \
+            HONEYCOMB_ENDPOINT='$HONEYCOMB_ENDPOINT' \
+            HONEYCOMB_API_KEY='$HONEYCOMB_API_KEY' \
+            GRAFANA_OTLP_ENDPOINT='$GRAFANA_OTLP_ENDPOINT' \
+            GRAFANA_OTLP_AUTH='$GRAFANA_OTLP_AUTH' \
+            SENTRY_OTLP_ENDPOINT='$SENTRY_OTLP_ENDPOINT' \
+            SENTRY_AUTH='$SENTRY_AUTH' \
+            SENTRY_AUTH_TOKEN='$SENTRY_AUTH_TOKEN' \
+            NEXT_PUBLIC_SENTRY_DSN='$NEXT_PUBLIC_SENTRY_DSN' \
+            NEXT_PUBLIC_STATSIG_CLIENT_KEY='$NEXT_PUBLIC_STATSIG_CLIENT_KEY' \
+            NEXT_PUBLIC_DATADOG_CLIENT_TOKEN='$NEXT_PUBLIC_DATADOG_CLIENT_TOKEN' \
+            NEXT_PUBLIC_DATADOG_APP_ID='$NEXT_PUBLIC_DATADOG_APP_ID' \
+            VITE_DATADOG_CLIENT_TOKEN='$VITE_DATADOG_CLIENT_TOKEN' \
+            VITE_DATADOG_APP_ID='$VITE_DATADOG_APP_ID' \
+            bash scripts/deploy-preview.sh"
+
+      - name: Comment preview URLs on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_DOMAIN: ${{ secrets.DEPLOY_BASE_DOMAIN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Preview environments are live:\n- https://pr-$PR_NUMBER.preview.$BASE_DOMAIN\n- https://custom-pr-$PR_NUMBER.preview.$BASE_DOMAIN\n- https://tanstack-pr-$PR_NUMBER.preview.$BASE_DOMAIN"
+
+  destroy-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync deployment artifacts to VM
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
+
+      - name: Destroy preview stack
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd /srv/obs/repo && chmod +x scripts/*.sh && PR_NUMBER='$PR_NUMBER' bash scripts/destroy-preview.sh"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,11 @@ permissions:
   packages: write
   pull-requests: write
 
+env:
+  TF_CLOUD_ORGANIZATION: ${{ vars.TF_CLOUD_ORGANIZATION }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_WORKSPACE_INFRA: ${{ vars.TF_WORKSPACE_INFRA }}
+
 jobs:
   deploy-preview:
     if: |
@@ -70,9 +75,34 @@ jobs:
             --build-arg VITE_DATADOG_APP_ID .
           docker push "$IMAGE_PREFIX/tanstack:$IMAGE_TAG"
 
+      - name: Read deploy host from HCP Terraform
+        uses: hashicorp/tfc-workflows-github/actions/workspace-output@v1.3.2
+        id: infra-outputs
+        with:
+          workspace: ${{ env.TF_WORKSPACE_INFRA }}
+
+      - name: Capture deploy connection settings
+        env:
+          INFRA_OUTPUTS_JSON: ${{ steps.infra-outputs.outputs.outputs }}
+        run: |
+          DEPLOY_HOST=$(jq -r '.[] | select(.attributes.name == "instance_main_ip") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+          DEPLOY_USER=$(jq -r '.[] | select(.attributes.name == "deploy_user") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+
+          if [ -z "$DEPLOY_HOST" ] || [ "$DEPLOY_HOST" = "null" ]; then
+            echo "Missing instance_main_ip output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          if [ -z "$DEPLOY_USER" ] || [ "$DEPLOY_USER" = "null" ]; then
+            echo "Missing deploy_user output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+          echo "DEPLOY_USER=$DEPLOY_USER" >> "$GITHUB_ENV"
+
       - name: Configure SSH
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           install -m 700 -d ~/.ssh
@@ -81,16 +111,11 @@ jobs:
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
 
       - name: Sync deployment artifacts to VM
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
 
       - name: Deploy preview stack
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_BASE_DOMAIN: ${{ secrets.DEPLOY_BASE_DOMAIN }}
           ACME_EMAIL: ${{ secrets.ACME_EMAIL }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -151,16 +176,43 @@ jobs:
           gh pr comment "$PR_NUMBER" --body "Preview environments are live:\n- https://pr-$PR_NUMBER.preview.$BASE_DOMAIN\n- https://custom-pr-$PR_NUMBER.preview.$BASE_DOMAIN\n- https://tanstack-pr-$PR_NUMBER.preview.$BASE_DOMAIN"
 
   destroy-preview:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Read deploy host from HCP Terraform
+        uses: hashicorp/tfc-workflows-github/actions/workspace-output@v1.3.2
+        id: infra-outputs
+        with:
+          workspace: ${{ env.TF_WORKSPACE_INFRA }}
+
+      - name: Capture deploy connection settings
+        env:
+          INFRA_OUTPUTS_JSON: ${{ steps.infra-outputs.outputs.outputs }}
+        run: |
+          DEPLOY_HOST=$(jq -r '.[] | select(.attributes.name == "instance_main_ip") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+          DEPLOY_USER=$(jq -r '.[] | select(.attributes.name == "deploy_user") | .attributes.value' <<<"$INFRA_OUTPUTS_JSON")
+
+          if [ -z "$DEPLOY_HOST" ] || [ "$DEPLOY_HOST" = "null" ]; then
+            echo "Missing instance_main_ip output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          if [ -z "$DEPLOY_USER" ] || [ "$DEPLOY_USER" = "null" ]; then
+            echo "Missing deploy_user output from HCP Terraform workspace $TF_WORKSPACE_INFRA" >&2
+            exit 1
+          fi
+
+          echo "DEPLOY_HOST=$DEPLOY_HOST" >> "$GITHUB_ENV"
+          echo "DEPLOY_USER=$DEPLOY_USER" >> "$GITHUB_ENV"
+
       - name: Configure SSH
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           install -m 700 -d ~/.ssh
@@ -169,16 +221,11 @@ jobs:
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
 
       - name: Sync deployment artifacts to VM
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           rsync -az --delete deploy scripts "$DEPLOY_USER@$DEPLOY_HOST:/srv/obs/repo/"
 
       - name: Destroy preview stack
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \

--- a/.github/workflows/terraform-apply-manual.yml
+++ b/.github/workflows/terraform-apply-manual.yml
@@ -1,0 +1,46 @@
+name: Terraform Apply Manual
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency: terraform-infra
+
+env:
+  TF_CLOUD_ORGANIZATION: ${{ vars.TF_CLOUD_ORGANIZATION }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_WORKSPACE: ${{ vars.TF_WORKSPACE_INFRA }}
+  CONFIG_DIRECTORY: ./infra
+
+jobs:
+  terraform-apply:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload Terraform configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        id: upload
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          directory: ${{ env.CONFIG_DIRECTORY }}
+
+      - name: Create apply run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        id: create-run
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
+          message: "Manual infra apply from GitHub Actions for ${{ github.sha }}"
+
+      - name: Confirm apply run
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.3.2
+        id: apply
+        if: fromJSON(steps.create-run.outputs.payload).data.attributes.actions.IsConfirmable
+        with:
+          run: ${{ steps.create-run.outputs.run_id }}
+          comment: "Confirmed manually from GitHub Actions for ${{ github.sha }}"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,50 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/**"
+
+permissions:
+  contents: read
+
+concurrency: terraform-infra
+
+env:
+  TF_CLOUD_ORGANIZATION: ${{ vars.TF_CLOUD_ORGANIZATION }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_WORKSPACE: ${{ vars.TF_WORKSPACE_INFRA }}
+  CONFIG_DIRECTORY: ./infra
+
+jobs:
+  terraform-apply:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload Terraform configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        id: upload
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          directory: ${{ env.CONFIG_DIRECTORY }}
+
+      - name: Create apply run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        id: create-run
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
+          message: "Infra apply from GitHub Actions for ${{ github.sha }}"
+
+      - name: Confirm apply run
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.3.2
+        id: apply
+        if: fromJSON(steps.create-run.outputs.payload).data.attributes.actions.IsConfirmable
+        with:
+          run: ${{ steps.create-run.outputs.run_id }}
+          comment: "Confirmed from GitHub Actions for ${{ github.sha }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,99 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "infra/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TF_CLOUD_ORGANIZATION: ${{ vars.TF_CLOUD_ORGANIZATION }}
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_WORKSPACE: ${{ vars.TF_WORKSPACE_INFRA }}
+  CONFIG_DIRECTORY: ./infra
+
+jobs:
+  terraform-plan:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload Terraform configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
+        id: upload
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          directory: ${{ env.CONFIG_DIRECTORY }}
+          speculative: true
+
+      - name: Create speculative plan run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.3.2
+        id: run
+        continue-on-error: true
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
+          plan_only: true
+          message: "Speculative infra plan from GitHub Actions for ${{ github.sha }}"
+
+      - name: Read plan output
+        uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.3.2
+        id: plan-output
+        if: steps.run.outputs.plan_id != ''
+        with:
+          plan: ${{ steps.run.outputs.plan_id }}
+
+      - name: Update PR with HCP Terraform plan
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('HCP Terraform Infra Plan Output')
+            })
+            const output = [
+              '#### HCP Terraform Infra Plan Output',
+              '',
+              '```',
+              `Plan: ${{ steps.plan-output.outputs.add || '0' }} to add, ${{ steps.plan-output.outputs.change || '0' }} to change, ${{ steps.plan-output.outputs.destroy || '0' }} to destroy.`,
+              '```',
+              `[HCP Terraform Run](${{ steps.run.outputs.run_link }})`,
+            ].join('\n')
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output,
+              })
+            }
+
+      - name: Fail if speculative run did not finish cleanly
+        if: steps.run.outputs.run_status != 'planned_and_finished'
+        run: |
+          echo "HCP Terraform plan did not finish cleanly"
+          echo "Run status: ${{ steps.run.outputs.run_status }}"
+          echo "Run URL: ${{ steps.run.outputs.run_link }}"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 .turbo
+.terraform/
 node_modules
 dist
 certs/
 .env
 .env.local
 *.tsbuildinfo
+*.tfstate
+*.tfstate.*
 datadog.yaml
 test-results/
 .tanstack/

--- a/README.md
+++ b/README.md
@@ -38,10 +38,69 @@ The deployment assets live in:
 - `deploy/router/Caddyfile.edge`
 - `deploy/router/Caddyfile.stack`
 - `infra/terraform/`
+- `infra/terraform/README.md`
 - `infra/cloud-init/user-data.yaml`
 - `scripts/deploy-stack.sh`
 - `scripts/deploy-preview.sh`
 - `scripts/destroy-preview.sh`
+
+## HCP Terraform
+
+Infrastructure is now integrated with HCP Terraform through GitHub Actions.
+
+- `terraform-plan.yml` creates speculative HCP Terraform runs for PRs that change `infra/**`
+- `terraform-apply.yml` applies infrastructure changes on `main` when `infra/**` changes
+- `deploy.yml` and `preview.yml` read `instance_main_ip` and `deploy_user` from the HCP Terraform workspace outputs before SSH deployment
+
+Set up the HCP Terraform workspace like this:
+
+1. Create an `API-driven` workspace.
+2. Set the working directory to `terraform`.
+3. Use the repository's `infra` directory as the uploaded configuration root.
+4. Keep execution mode as remote unless you have a private-runner requirement.
+
+Required GitHub repository configuration:
+
+- Repository variable: `TF_CLOUD_ORGANIZATION`
+- Repository variable: `TF_WORKSPACE_INFRA`
+- Repository secret: `TF_API_TOKEN`
+
+Required HCP Terraform workspace variables:
+
+- Environment variable: `VULTR_API_KEY`
+- Terraform variable: `instance_region`
+- Terraform variable: `deploy_authorized_key`
+
+For the exact HCP Terraform and Vultr bootstrap checklist, see `infra/terraform/README.md`.
+
+Common optional HCP Terraform workspace variables:
+
+- Terraform variable: `domain_name`
+- Terraform variable: `instance_plan`
+- Terraform variable: `enable_dnssec`
+- Terraform variable: `enable_instance_backups`
+- Terraform variable: `deploy_user`
+
+App deployment workflows still require GitHub secrets for runtime and deploy configuration:
+
+- `DEPLOY_SSH_KEY`
+- `DEPLOY_BASE_DOMAIN`
+- `ACME_EMAIL`
+- `DD_API_KEY`
+- `DD_SITE`
+- `HONEYCOMB_ENDPOINT`
+- `HONEYCOMB_API_KEY`
+- `GRAFANA_OTLP_ENDPOINT`
+- `GRAFANA_OTLP_AUTH`
+- `SENTRY_OTLP_ENDPOINT`
+- `SENTRY_AUTH`
+- `SENTRY_AUTH_TOKEN`
+- `NEXT_PUBLIC_SENTRY_DSN`
+- `NEXT_PUBLIC_STATSIG_CLIENT_KEY`
+- `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`
+- `NEXT_PUBLIC_DATADOG_APP_ID`
+- `VITE_DATADOG_CLIENT_TOKEN`
+- `VITE_DATADOG_APP_ID`
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A multi-service reference implementation demonstrating distributed tracing with OpenTelemetry across Next.js, Express, and GraphQL.
 
+The repo now includes a single-VM deployment model for main and preview environments using Docker Compose, Caddy, Terraform, and cloud-init.
+
 ## Architecture
 
 - **Next.js** (port 3000) - Frontend UI
@@ -10,6 +12,36 @@ A multi-service reference implementation demonstrating distributed tracing with 
 - **HTTPS Proxy** (port 443) - Unified development server
 
 Services export traces to Honeycomb, Grafana Cloud, Sentry, and Datadog.
+
+## Deployment
+
+Production and preview deployments are designed around one always-on VM:
+
+- One global Caddy edge proxy on `80/443`
+- One isolated Docker Compose project for the main stack
+- One isolated Docker Compose project per pull request preview
+- One stack-local Datadog Agent per deployment stack
+
+Hostnames are expected to follow this pattern:
+
+- Main app: `app.<your-domain>`
+- Main custom server: `custom.<your-domain>`
+- Main TanStack app: `tanstack.<your-domain>`
+- Preview app: `pr-<number>.preview.<your-domain>`
+- Preview custom server: `custom-pr-<number>.preview.<your-domain>`
+- Preview TanStack app: `tanstack-pr-<number>.preview.<your-domain>`
+
+The deployment assets live in:
+
+- `deploy/compose/stack.yaml`
+- `deploy/compose/edge.yaml`
+- `deploy/router/Caddyfile.edge`
+- `deploy/router/Caddyfile.stack`
+- `infra/terraform/`
+- `infra/cloud-init/user-data.yaml`
+- `scripts/deploy-stack.sh`
+- `scripts/deploy-preview.sh`
+- `scripts/destroy-preview.sh`
 
 ## Prerequisites
 
@@ -43,10 +75,8 @@ mkdir certs
 Start all services:
 
 ```bash
-npm run dev:all        # With built-in Next.js server
-npm run dev:all:custom # With custom Next.js server
-npm run dev:dd:all     # With built-in Next.js server and Datadog native tracing
-npm run dev:dd:custom  # With custom Next.js server and Datadog native tracing
+npm run dev:all     # Built-in Next.js, custom Next.js, Express, GraphQL, TanStack, proxy
+npm run dev:dd:all  # Same stack with Datadog native tracing enabled
 ```
 
 Access the app:
@@ -57,6 +87,17 @@ Access the app:
 - GraphQL Playground: http://localhost:4000/graphql
 
 Using native Datadog tracing requires that you have the datadog agent setup locally with opentelemetry ingest/egress enabled.
+
+## SQLite
+
+If one or two services need lightweight relational storage, keep SQLite files on stack-local persistent volumes. That fits this single-VM deployment model well, but only while the database file remains local to the VM and write concurrency stays modest.
+
+The deployment tooling reserves these service-local data paths:
+
+- Express: `/var/lib/obs/express`
+- GraphQL: `/var/lib/obs/graphql`
+
+Use `scripts/backup-sqlite.sh` on the host to snapshot the current service volumes for a stack.
 
 ## Development
 

--- a/apps/express-server/Dockerfile
+++ b/apps/express-server/Dockerfile
@@ -1,0 +1,32 @@
+ARG NODE_VERSION=24
+
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps/express-server/package.json apps/express-server/package.json
+COPY packages/env/package.json packages/env/package.json
+COPY packages/graphql-client/package.json packages/graphql-client/package.json
+COPY packages/otel/package.json packages/otel/package.json
+RUN npm ci
+
+FROM deps AS builder
+WORKDIR /app
+COPY . .
+RUN npm run build --workspace=@obs-playground/env \
+  && npm run build --workspace=@obs-playground/graphql-client \
+  && npm run build --workspace=@obs-playground/otel \
+  && npm run build --workspace=express-server \
+  && npm prune --omit=dev
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json /app/package-lock.json /app/turbo.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/express-server ./apps/express-server
+COPY --from=builder /app/packages/env ./packages/env
+COPY --from=builder /app/packages/graphql-client ./packages/graphql-client
+COPY --from=builder /app/packages/otel ./packages/otel
+EXPOSE 3001
+CMD ["node", "apps/express-server/dist/index.js"]

--- a/apps/graphql-server/Dockerfile
+++ b/apps/graphql-server/Dockerfile
@@ -1,0 +1,29 @@
+ARG NODE_VERSION=24
+
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps/graphql-server/package.json apps/graphql-server/package.json
+COPY packages/env/package.json packages/env/package.json
+COPY packages/otel/package.json packages/otel/package.json
+RUN npm ci
+
+FROM deps AS builder
+WORKDIR /app
+COPY . .
+RUN npm run build --workspace=@obs-playground/env \
+  && npm run build --workspace=@obs-playground/otel \
+  && npm run build --workspace=graphql-server \
+  && npm prune --omit=dev
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json /app/package-lock.json /app/turbo.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/graphql-server ./apps/graphql-server
+COPY --from=builder /app/packages/env ./packages/env
+COPY --from=builder /app/packages/otel ./packages/otel
+EXPOSE 4000
+CMD ["node", "apps/graphql-server/dist/index.js"]

--- a/apps/nextjs-app/Dockerfile
+++ b/apps/nextjs-app/Dockerfile
@@ -1,0 +1,41 @@
+ARG NODE_VERSION=24
+
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps/nextjs-app/package.json apps/nextjs-app/package.json
+COPY packages/env/package.json packages/env/package.json
+COPY packages/graphql-client/package.json packages/graphql-client/package.json
+COPY packages/otel/package.json packages/otel/package.json
+RUN npm ci
+
+FROM deps AS builder
+WORKDIR /app
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ARG NEXT_PUBLIC_STATSIG_CLIENT_KEY=""
+ARG NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=""
+ARG NEXT_PUBLIC_DATADOG_APP_ID=""
+COPY . .
+ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+ENV NEXT_PUBLIC_STATSIG_CLIENT_KEY=${NEXT_PUBLIC_STATSIG_CLIENT_KEY}
+ENV NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=${NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}
+ENV NEXT_PUBLIC_DATADOG_APP_ID=${NEXT_PUBLIC_DATADOG_APP_ID}
+RUN npm run build --workspace=@obs-playground/env \
+  && npm run build --workspace=@obs-playground/graphql-client \
+  && npm run build --workspace=@obs-playground/otel \
+  && npm run build --workspace=nextjs-app \
+  && npm run build:custom --workspace=nextjs-app \
+  && npm prune --omit=dev
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json /app/package-lock.json /app/turbo.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/nextjs-app ./apps/nextjs-app
+COPY --from=builder /app/packages/env ./packages/env
+COPY --from=builder /app/packages/graphql-client ./packages/graphql-client
+COPY --from=builder /app/packages/otel ./packages/otel
+EXPOSE 3000
+CMD ["npm", "run", "start", "--workspace=nextjs-app"]

--- a/apps/tanstack-start/Dockerfile
+++ b/apps/tanstack-start/Dockerfile
@@ -1,0 +1,36 @@
+ARG NODE_VERSION=24
+
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps/tanstack-start/package.json apps/tanstack-start/package.json
+COPY packages/env/package.json packages/env/package.json
+COPY packages/graphql-client/package.json packages/graphql-client/package.json
+COPY packages/otel/package.json packages/otel/package.json
+RUN npm ci
+
+FROM deps AS builder
+WORKDIR /app
+ARG VITE_DATADOG_CLIENT_TOKEN=""
+ARG VITE_DATADOG_APP_ID=""
+COPY . .
+ENV VITE_DATADOG_CLIENT_TOKEN=${VITE_DATADOG_CLIENT_TOKEN}
+ENV VITE_DATADOG_APP_ID=${VITE_DATADOG_APP_ID}
+RUN npm run build --workspace=@obs-playground/env \
+  && npm run build --workspace=@obs-playground/graphql-client \
+  && npm run build --workspace=@obs-playground/otel \
+  && npm run build --workspace=tanstack-start \
+  && npm prune --omit=dev
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json /app/package-lock.json /app/turbo.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/tanstack-start ./apps/tanstack-start
+COPY --from=builder /app/packages/env ./packages/env
+COPY --from=builder /app/packages/graphql-client ./packages/graphql-client
+COPY --from=builder /app/packages/otel ./packages/otel
+EXPOSE 3100
+CMD ["node", "apps/tanstack-start/.output/server/index.mjs"]

--- a/deploy/compose/edge.yaml
+++ b/deploy/compose/edge.yaml
@@ -1,0 +1,18 @@
+services:
+  edge:
+    image: caddy:2.10-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - ../router/Caddyfile.edge:/etc/caddy/Caddyfile:ro
+      - ${EDGE_ROUTES_DIR:-/srv/obs/edge/routes}:/etc/caddy/routes:ro
+      - edge-data:/data
+      - edge-config:/config
+
+volumes:
+  edge-data:
+  edge-config:

--- a/deploy/compose/stack.yaml
+++ b/deploy/compose/stack.yaml
@@ -1,0 +1,160 @@
+services:
+  router:
+    image: caddy:2.10-alpine
+    restart: unless-stopped
+    depends_on:
+      - nextjs
+      - nextjs-custom
+      - express
+      - graphql
+      - tanstack
+    environment:
+      NEXT_HOST: ${NEXT_HOST}
+      CUSTOM_HOST: ${CUSTOM_HOST}
+      TANSTACK_HOST: ${TANSTACK_HOST}
+    ports:
+      - "127.0.0.1:${STACK_ROUTER_PORT}:8080"
+    volumes:
+      - ../router/Caddyfile.stack:/etc/caddy/Caddyfile:ro
+    networks:
+      - backplane
+
+  nextjs:
+    image: ${OBS_NEXTJS_IMAGE}
+    restart: unless-stopped
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      GRAPHQL_BASE_URL: http://graphql:4000
+      EXPRESS_BASE_URL: http://express:3001
+      DD_AGENT_HOST: datadog-agent
+      DD_TRACE_AGENT_PORT: 8126
+      DATADOG_OTLP_ENDPOINT: http://datadog-agent:4318
+      DD_SERVICE: obs-nextjs
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+    networks:
+      - backplane
+
+  nextjs-custom:
+    image: ${OBS_NEXTJS_IMAGE}
+    restart: unless-stopped
+    command: ["node", "apps/nextjs-app/server.ts"]
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      NODE_ENV: production
+      CUSTOM_SERVER: "true"
+      PORT: 3002
+      GRAPHQL_BASE_URL: http://graphql:4000
+      EXPRESS_BASE_URL: http://express:3001
+      DD_AGENT_HOST: datadog-agent
+      DD_TRACE_AGENT_PORT: 8126
+      DATADOG_OTLP_ENDPOINT: http://datadog-agent:4318
+      DD_SERVICE: obs-nextjs-custom
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+    networks:
+      - backplane
+
+  express:
+    image: ${OBS_EXPRESS_IMAGE}
+    restart: unless-stopped
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      GRAPHQL_BASE_URL: http://graphql:4000
+      DD_AGENT_HOST: datadog-agent
+      DD_TRACE_AGENT_PORT: 8126
+      DATADOG_OTLP_ENDPOINT: http://datadog-agent:4318
+      DD_SERVICE: obs-express
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+      SQLITE_DATA_DIR: /var/lib/obs/express
+    volumes:
+      - express-data:/var/lib/obs/express
+    networks:
+      - backplane
+
+  graphql:
+    image: ${OBS_GRAPHQL_IMAGE}
+    restart: unless-stopped
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      NODE_ENV: production
+      PORT: 4000
+      EXPRESS_BASE_URL: http://express:3001
+      DD_AGENT_HOST: datadog-agent
+      DD_TRACE_AGENT_PORT: 8126
+      DATADOG_OTLP_ENDPOINT: http://datadog-agent:4318
+      DD_SERVICE: obs-graphql
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+      SQLITE_DATA_DIR: /var/lib/obs/graphql
+    volumes:
+      - graphql-data:/var/lib/obs/graphql
+    networks:
+      - backplane
+
+  tanstack:
+    image: ${OBS_TANSTACK_IMAGE}
+    restart: unless-stopped
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      NODE_ENV: production
+      PORT: 3100
+      GRAPHQL_BASE_URL: http://graphql:4000
+      EXPRESS_BASE_URL: http://express:3001
+      DD_AGENT_HOST: datadog-agent
+      DD_TRACE_AGENT_PORT: 8126
+      DATADOG_OTLP_ENDPOINT: http://datadog-agent:4318
+      DD_SERVICE: obs-tanstack
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+    networks:
+      - backplane
+
+  datadog-agent:
+    image: registry.datadoghq.com/agent:latest
+    restart: unless-stopped
+    pid: host
+    env_file:
+      - ${STACK_ENV_FILE:-./stack.env}
+    environment:
+      DD_APM_ENABLED: "true"
+      DD_APM_NON_LOCAL_TRAFFIC: "true"
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: 0.0.0.0:4318
+      DD_LOGS_ENABLED: ${DD_LOGS_ENABLED:-false}
+      DD_OTLP_CONFIG_LOGS_ENABLED: ${DD_OTLP_CONFIG_LOGS_ENABLED:-false}
+      DD_ENV: ${STACK_ENV}
+      DD_VERSION: ${STACK_VERSION}
+      DD_TAGS: stack:${STACK_NAME},preview_id:${PREVIEW_ID}
+      HOST_PROC: /proc
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc:/host/proc:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /opt/datadog-agent/run:/opt/datadog-agent/run:rw
+    networks:
+      - backplane
+
+networks:
+  backplane:
+    internal: true
+
+volumes:
+  express-data:
+  graphql-data:

--- a/deploy/router/Caddyfile.edge
+++ b/deploy/router/Caddyfile.edge
@@ -1,0 +1,9 @@
+{
+  email {$ACME_EMAIL}
+}
+
+:80, :443 {
+  respond "No edge route configured" 404
+}
+
+import /etc/caddy/routes/*.caddy

--- a/deploy/router/Caddyfile.stack
+++ b/deploy/router/Caddyfile.stack
@@ -1,0 +1,54 @@
+{
+  auto_https off
+  http_port 8080
+}
+
+{$NEXT_HOST} {
+  handle /graphql* {
+    reverse_proxy graphql:4000
+  }
+
+  handle_path /api/* {
+    reverse_proxy express:3001
+  }
+
+  handle /tanstack* {
+    reverse_proxy tanstack:3100
+  }
+
+  handle {
+    reverse_proxy nextjs:3000
+  }
+}
+
+{$CUSTOM_HOST} {
+  handle /graphql* {
+    reverse_proxy graphql:4000
+  }
+
+  handle_path /api/* {
+    reverse_proxy express:3001
+  }
+
+  handle /tanstack* {
+    reverse_proxy tanstack:3100
+  }
+
+  handle {
+    reverse_proxy nextjs-custom:3002
+  }
+}
+
+{$TANSTACK_HOST} {
+  handle /graphql* {
+    reverse_proxy graphql:4000
+  }
+
+  handle_path /api/* {
+    reverse_proxy express:3001
+  }
+
+  handle {
+    reverse_proxy tanstack:3100
+  }
+}

--- a/infra/.terraformignore
+++ b/infra/.terraformignore
@@ -1,0 +1,3 @@
+.terraform/
+terraform.tfstate
+terraform.tfstate.*

--- a/infra/cloud-init/user-data.yaml
+++ b/infra/cloud-init/user-data.yaml
@@ -1,0 +1,38 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - ca-certificates
+  - curl
+  - git
+  - gnupg
+  - lsb-release
+  - rsync
+  - unzip
+
+users:
+  - default
+  - name: ${deploy_user}
+    gecos: OpenTelemetry Preview Deploy User
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: sudo
+    ssh_authorized_keys:
+      - ${deploy_authorized_key}
+
+runcmd:
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - bash -lc 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list'
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - systemctl enable docker
+  - systemctl start docker
+  - usermod -aG docker ${deploy_user}
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs/backups
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs/edge
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs/edge/routes
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs/repo
+  - install -d -m 0755 -o ${deploy_user} -g ${deploy_user} /srv/obs/stacks

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/vultr/vultr" {
+  version     = "2.27.1"
+  constraints = "2.27.1"
+  hashes = [
+    "h1:03veypY7WtdR3vHzy2/j6M0Zmuo7IyfwkqqqM6hLjWw=",
+    "zh:258d785a466690a8fb4e9b66ded5bcfe2278f9f5405a2378c0b4f7c4d36e0c8a",
+    "zh:2e41bdbde0dfe3c2efad5a758242afb5f4ffd2a4011c0116273f261153350416",
+    "zh:337f57803fc981dfbfa3cc33a1da815d16b32f410ee5ebf3ca23e3f99a5c2fbd",
+    "zh:4c3147de502d1189f6c5b344fab0529ecfc72a1c55c97813610d9e165c409c36",
+    "zh:5ab1c11d5db6752e5f191bd5a353445beb3644d8abcfe69235cc72ae735827bf",
+    "zh:5dbae73ff2a059ba1bbcf8c76ccf877bb44c53028ae407b3bdf00c6be9c50426",
+    "zh:6b17163945bddb89d24ef5cb9af1efb9d189add0a75f6621cf1a2b86ad156e44",
+    "zh:8aee9d6ae2a087bdb925b527c702fd3dae66e82cf18abecce128e0ba483064a8",
+    "zh:914453131253e1a68b2a7f0241abd181ddd2ddc9b2a4487f4710121f33a1cf29",
+    "zh:9dd846e7c06f0fba3705dc113b358a5d735c53b624c13561cf2e79ffe0d65d1a",
+    "zh:beae990bf06a283255a2448b600bdc5b341fa0ce4f2b236046f73eb227053f7e",
+    "zh:c9acfb9285eb51fbdaa8de1b56b6816e233b86124442e9f49982b2b8ae8de246",
+    "zh:ea9f66cd35f7422ec2c29d09160d6621063e3c3fa64f24a5210c21413c7d62d3",
+    "zh:eaf35df48d717879da8b0a962dea13e7d1926f016a27e0f32c11272d68fbac5d",
+    "zh:f1ee0ad592060cc9d69270a10b44f508414c029ce5859b760e59c11a1b3c0d43",
+    "zh:ff6ffae0eed9953dd68939f484460a58670c881fb9b7d828352b142dced662f7",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,100 @@
+# HCP Terraform Bootstrap
+
+This repo uses HCP Terraform to provision the single Vultr VM and related firewall/DNS resources, and GitHub Actions reads the resulting workspace outputs before deploying app containers. Sources: `../.github/workflows/terraform-plan.yml`, `../.github/workflows/terraform-apply.yml`, `../.github/workflows/deploy.yml`, `../.github/workflows/preview.yml`, `./terraform/outputs.tf`
+
+## Exact Setup
+
+1. In HCP Terraform, create one workspace for this repo's infrastructure.
+   Use an `API-driven` workspace and set the workspace working directory to `terraform`. The GitHub workflows upload the `./infra` directory, and the Terraform config itself lives under `infra/terraform`. Sources: `../.github/workflows/terraform-plan.yml`, `../.github/workflows/terraform-apply.yml`, `./terraform/main.tf`, `https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#terraform-working-directory`
+
+2. In that HCP workspace, add these variables.
+   Environment variables:
+
+- `VULTR_API_KEY=<your Vultr API key>`
+
+Terraform variables:
+
+- `instance_region="ewr"` or another US Vultr region ID
+- `deploy_authorized_key="ssh-ed25519 AAAA..."`
+
+Optional Terraform variables:
+
+- `domain_name="yourdomain.com"`
+- `instance_plan="vc2-2c-4gb"`
+- `enable_dnssec=false`
+- `enable_instance_backups=false`
+- `deploy_user="obsdeploy"`
+
+`VULTR_API_KEY` is how the Vultr provider authenticates, and `instance_region` plus `deploy_authorized_key` are the required infra inputs in this repo. Sources: `./terraform/variables.tf`, `./terraform/providers.tf`, `https://docs.vultr.com/reference/terraform`
+
+3. Generate the SSH keypair used by deployments if you do not already have one.
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/obsdeploy
+```
+
+Put the public key in the HCP Terraform variable `deploy_authorized_key`, and keep the private key for the GitHub secret `DEPLOY_SSH_KEY`. Sources: `./terraform/variables.tf`, `../cloud-init/user-data.yaml`, `../.github/workflows/deploy.yml`, `../.github/workflows/preview.yml`
+
+4. Decide how DNS will work before the first apply.
+   If your domain's authoritative DNS will be hosted in Vultr, set `domain_name` in the HCP workspace and Terraform will create:
+
+- `app.<domain>`
+- `custom.<domain>`
+- `tanstack.<domain>`
+- `*.preview.<domain>`
+
+If your domain stays with another DNS provider, leave `domain_name` unset or empty and create those four records manually after the VM is provisioned. Sources: `./terraform/main.tf`, `./terraform/variables.tf`, `./terraform/outputs.tf`
+
+5. In GitHub, add these repository variables.
+
+- `TF_CLOUD_ORGANIZATION`
+- `TF_WORKSPACE_INFRA`
+
+Add these repository secrets.
+
+- `TF_API_TOKEN`
+- `DEPLOY_SSH_KEY`
+- `DEPLOY_BASE_DOMAIN`
+- `ACME_EMAIL`
+- `DD_API_KEY`
+- `DD_SITE`
+- `HONEYCOMB_ENDPOINT`
+- `HONEYCOMB_API_KEY`
+- `GRAFANA_OTLP_ENDPOINT`
+- `GRAFANA_OTLP_AUTH`
+- `SENTRY_OTLP_ENDPOINT`
+- `SENTRY_AUTH`
+- `SENTRY_AUTH_TOKEN`
+- `NEXT_PUBLIC_SENTRY_DSN`
+- `NEXT_PUBLIC_STATSIG_CLIENT_KEY`
+- `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`
+- `NEXT_PUBLIC_DATADOG_APP_ID`
+- `VITE_DATADOG_CLIENT_TOKEN`
+- `VITE_DATADOG_APP_ID`
+
+The Terraform workflows use `TF_CLOUD_ORGANIZATION`, `TF_WORKSPACE_INFRA`, and `TF_API_TOKEN`; the deploy workflows use the rest. Sources: `../.github/workflows/terraform-plan.yml`, `../.github/workflows/terraform-apply.yml`, `../.github/workflows/deploy.yml`, `../.github/workflows/preview.yml`
+
+6. Trigger infrastructure once.
+   Push a change under `infra/**` to run `Terraform Apply` on `main`, or run that workflow manually if you prefer. That workflow uploads the `infra` directory to HCP Terraform and creates/applies the run in the configured workspace. Source: `../.github/workflows/terraform-apply.yml`
+
+7. Confirm the workspace outputs exist after apply.
+   You should see at least:
+
+- `instance_main_ip`
+- `deploy_user`
+
+The app deploy workflows read those outputs from HCP Terraform before they SSH to the host. Sources: `./terraform/outputs.tf`, `../.github/workflows/deploy.yml`, `../.github/workflows/preview.yml`, `https://github.com/hashicorp/tfc-workflows-github/blob/main/actions/README.md`
+
+8. Merge to `main` for app deploys and open same-repo PRs for preview deploys.
+   Main deploys and preview deploys are both gated on the `CI` workflow succeeding first. Sources: `../.github/workflows/deploy.yml`, `../.github/workflows/preview.yml`, `../.github/workflows/ci.yml`
+
+## Minimal Vultr Setup
+
+You do not need to pre-create a VM, firewall, or DNS records in the Vultr UI for this repo. Terraform creates the firewall group, firewall rules, the VM, and optionally the DNS zone and records from the HCP workspace run. Sources: `./terraform/main.tf`, `https://docs.vultr.com/reference/terraform`
+
+The only Vultr prerequisite assumed here is:
+
+- you already have a Vultr account
+- you already have a Vultr API key
+
+Put that key into the HCP Terraform workspace as the environment variable `VULTR_API_KEY`. Sources: `./terraform/providers.tf`, `https://docs.vultr.com/reference/terraform`

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,101 @@
+locals {
+  dns_enabled = trim(var.domain_name) != ""
+}
+
+resource "vultr_firewall_group" "preview_host" {
+  description = "${var.project_name} ingress firewall"
+}
+
+resource "vultr_firewall_rule" "ssh" {
+  firewall_group_id = vultr_firewall_group.preview_host.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "22"
+  notes             = "SSH"
+}
+
+resource "vultr_firewall_rule" "http" {
+  firewall_group_id = vultr_firewall_group.preview_host.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "80"
+  notes             = "HTTP"
+}
+
+resource "vultr_firewall_rule" "https" {
+  firewall_group_id = vultr_firewall_group.preview_host.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "443"
+  notes             = "HTTPS"
+}
+
+resource "vultr_instance" "preview_host" {
+  plan              = var.instance_plan
+  region            = var.instance_region
+  os_id             = var.os_id
+  label             = var.instance_label
+  hostname          = var.instance_hostname
+  firewall_group_id = vultr_firewall_group.preview_host.id
+  ssh_key_ids       = var.ssh_key_ids
+  backups           = var.enable_instance_backups ? "enabled" : "disabled"
+  activation_email  = false
+  user_data = templatefile("${path.module}/../cloud-init/user-data.yaml", {
+    deploy_user           = var.deploy_user
+    deploy_authorized_key = trimspace(var.deploy_authorized_key)
+  })
+  tags = [
+    var.project_name,
+    "preview-host",
+    "us-region",
+  ]
+}
+
+resource "vultr_dns_domain" "preview_host" {
+  count   = local.dns_enabled ? 1 : 0
+  domain  = var.domain_name
+  ip      = vultr_instance.preview_host.main_ip
+  dns_sec = var.enable_dnssec ? "enabled" : "disabled"
+}
+
+resource "vultr_dns_record" "app" {
+  count  = local.dns_enabled ? 1 : 0
+  domain = vultr_dns_domain.preview_host[0].id
+  name   = "app"
+  type   = "A"
+  data   = vultr_instance.preview_host.main_ip
+  ttl    = 300
+}
+
+resource "vultr_dns_record" "custom" {
+  count  = local.dns_enabled ? 1 : 0
+  domain = vultr_dns_domain.preview_host[0].id
+  name   = "custom"
+  type   = "A"
+  data   = vultr_instance.preview_host.main_ip
+  ttl    = 300
+}
+
+resource "vultr_dns_record" "tanstack" {
+  count  = local.dns_enabled ? 1 : 0
+  domain = vultr_dns_domain.preview_host[0].id
+  name   = "tanstack"
+  type   = "A"
+  data   = vultr_instance.preview_host.main_ip
+  ttl    = 300
+}
+
+resource "vultr_dns_record" "preview_wildcard" {
+  count  = local.dns_enabled ? 1 : 0
+  domain = vultr_dns_domain.preview_host[0].id
+  name   = "*.${var.preview_domain_label}"
+  type   = "A"
+  data   = vultr_instance.preview_host.main_ip
+  ttl    = 300
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,5 +1,5 @@
 locals {
-  dns_enabled = trim(var.domain_name) != ""
+  dns_enabled = trimspace(var.domain_name) != ""
 }
 
 resource "vultr_firewall_group" "preview_host" {

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_main_ip" {
+  description = "Public IPv4 address of the single preview host VM."
+  value       = vultr_instance.preview_host.main_ip
+}
+
+output "instance_id" {
+  description = "Vultr instance ID for the preview host VM."
+  value       = vultr_instance.preview_host.id
+}
+
+output "managed_domain" {
+  description = "Managed DNS domain, if DNS resources are enabled."
+  value       = local.dns_enabled ? vultr_dns_domain.preview_host[0].domain : null
+}
+
+output "main_hosts" {
+  description = "Primary hostnames expected by the deployment."
+  value = local.dns_enabled ? {
+    app      = "app.${var.domain_name}"
+    custom   = "custom.${var.domain_name}"
+    tanstack = "tanstack.${var.domain_name}"
+    preview  = "*.${var.preview_domain_label}.${var.domain_name}"
+  } : null
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -8,6 +8,11 @@ output "instance_id" {
   value       = vultr_instance.preview_host.id
 }
 
+output "deploy_user" {
+  description = "Linux deployment user created by cloud-init."
+  value       = var.deploy_user
+}
+
 output "managed_domain" {
   description = "Managed DNS domain, if DNS resources are enabled."
   value       = local.dns_enabled ? vultr_dns_domain.preview_host[0].domain : null

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = "2.27.1"
+    }
+  }
+}
+
+provider "vultr" {}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,76 @@
+variable "project_name" {
+  description = "Name prefix for the single preview host VM."
+  type        = string
+  default     = "obs-playground"
+}
+
+variable "instance_label" {
+  description = "Vultr instance label."
+  type        = string
+  default     = "obs-playground"
+}
+
+variable "instance_hostname" {
+  description = "Hostname assigned to the VM."
+  type        = string
+  default     = "obs-playground"
+}
+
+variable "instance_region" {
+  description = "US-based Vultr region ID, for example ewr or atl."
+  type        = string
+}
+
+variable "instance_plan" {
+  description = "Vultr plan ID for the VM."
+  type        = string
+  default     = "vc2-2c-4gb"
+}
+
+variable "os_id" {
+  description = "Vultr OS ID for the VM image."
+  type        = number
+  default     = 1743
+}
+
+variable "ssh_key_ids" {
+  description = "SSH key IDs to install on the instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "deploy_user" {
+  description = "Linux user that receives deployment SSH access."
+  type        = string
+  default     = "obsdeploy"
+}
+
+variable "deploy_authorized_key" {
+  description = "Public SSH key for the deployment user."
+  type        = string
+  sensitive   = true
+}
+
+variable "domain_name" {
+  description = "Root DNS zone already purchased by the team. Leave empty to skip DNS management."
+  type        = string
+  default     = ""
+}
+
+variable "enable_dnssec" {
+  description = "Whether to enable DNSSEC on the managed DNS zone."
+  type        = bool
+  default     = false
+}
+
+variable "preview_domain_label" {
+  description = "Second-level label used for wildcard preview DNS entries."
+  type        = string
+  default     = "preview"
+}
+
+variable "enable_instance_backups" {
+  description = "Whether Vultr automated instance backups should be enabled."
+  type        = bool
+  default     = false
+}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -8,6 +8,17 @@ function normalizeBaseUrl(base: string): string {
   return `http://${trimmedBase}`;
 }
 
+function getBrowserOrigin(): string | undefined {
+  const browserGlobal = globalThis as typeof globalThis & {
+    location?: {
+      origin?: string;
+    };
+  };
+  const browserOrigin = browserGlobal.location?.origin;
+
+  return typeof browserOrigin === "string" ? browserOrigin : undefined;
+}
+
 export function getGraphqlUrl(): string {
   if (!process.env.GRAPHQL_BASE_URL) {
     throw new Error("GRAPHQL_BASE_URL environment variable is required");
@@ -38,11 +49,13 @@ function getViteGraphqlBaseUrl(): string | undefined {
 
 export function getPublicGraphqlUrl(): string {
   const base =
-    getViteGraphqlBaseUrl() ?? process.env.NEXT_PUBLIC_GRAPHQL_BASE_URL;
+    getViteGraphqlBaseUrl() ??
+    process.env.NEXT_PUBLIC_GRAPHQL_BASE_URL ??
+    getBrowserOrigin();
 
   if (!base) {
     throw new Error(
-      "VITE_GRAPHQL_BASE_URL or NEXT_PUBLIC_GRAPHQL_BASE_URL environment variable is required",
+      "VITE_GRAPHQL_BASE_URL, NEXT_PUBLIC_GRAPHQL_BASE_URL, or a browser origin is required",
     );
   }
 

--- a/scripts/backup-sqlite.sh
+++ b/scripts/backup-sqlite.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "${STACK_NAME:-}" ]; then
+  printf 'Missing required environment variable: STACK_NAME\n' >&2
+  exit 1
+fi
+
+BACKUP_ROOT=${BACKUP_ROOT:-/srv/obs/backups}
+TIMESTAMP=${TIMESTAMP:-$(date +%Y%m%d%H%M%S)}
+DESTINATION_DIR="$BACKUP_ROOT/$STACK_NAME/$TIMESTAMP"
+
+mkdir -p "$DESTINATION_DIR"
+
+backup_volume() {
+  local volume_name="$1"
+  local archive_name="$2"
+
+  docker run --rm \
+    -v "${volume_name}:/source:ro" \
+    -v "${DESTINATION_DIR}:/backup" \
+    alpine:3.22 \
+    tar czf "/backup/${archive_name}" -C /source .
+}
+
+backup_volume "${STACK_NAME}_express-data" "express-data.tgz"
+backup_volume "${STACK_NAME}_graphql-data" "graphql-data.tgz"
+
+printf 'Backed up SQLite volumes for %s to %s\n' "$STACK_NAME" "$DESTINATION_DIR"

--- a/scripts/deploy-preview.sh
+++ b/scripts/deploy-preview.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+required_vars=(
+  PR_NUMBER
+  BASE_DOMAIN
+  IMAGE_TAG
+  ACME_EMAIL
+  OBS_NEXTJS_IMAGE
+  OBS_EXPRESS_IMAGE
+  OBS_GRAPHQL_IMAGE
+  OBS_TANSTACK_IMAGE
+  DD_API_KEY
+)
+
+for var_name in "${required_vars[@]}"; do
+  if [ -z "${!var_name:-}" ]; then
+    printf 'Missing required environment variable: %s\n' "$var_name" >&2
+    exit 1
+  fi
+done
+
+STACK_NAME="obs-pr-${PR_NUMBER}"
+PREVIEW_ID="pr-${PR_NUMBER}"
+STACK_ROUTER_PORT=$((20000 + (PR_NUMBER % 10000)))
+
+export STACK_NAME
+export PREVIEW_ID
+export STACK_ROUTER_PORT
+export STACK_ENV=preview
+export STACK_VERSION="${IMAGE_TAG}"
+export NEXT_HOST="pr-${PR_NUMBER}.preview.${BASE_DOMAIN}"
+export CUSTOM_HOST="custom-pr-${PR_NUMBER}.preview.${BASE_DOMAIN}"
+export TANSTACK_HOST="tanstack-pr-${PR_NUMBER}.preview.${BASE_DOMAIN}"
+
+bash "$ROOT_DIR/scripts/deploy-stack.sh"

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+STACK_ROOT=${STACK_ROOT:-/srv/obs/stacks}
+EDGE_ROUTES_DIR=${EDGE_ROUTES_DIR:-/srv/obs/edge/routes}
+
+required_vars=(
+  ACME_EMAIL
+  STACK_NAME
+  STACK_ENV
+  STACK_VERSION
+  STACK_ROUTER_PORT
+  NEXT_HOST
+  CUSTOM_HOST
+  TANSTACK_HOST
+  OBS_NEXTJS_IMAGE
+  OBS_EXPRESS_IMAGE
+  OBS_GRAPHQL_IMAGE
+  OBS_TANSTACK_IMAGE
+  DD_API_KEY
+)
+
+for var_name in "${required_vars[@]}"; do
+  if [ -z "${!var_name:-}" ]; then
+    printf 'Missing required environment variable: %s\n' "$var_name" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$STACK_ROOT/$STACK_NAME" "$EDGE_ROUTES_DIR"
+
+STACK_ENV_FILE="$STACK_ROOT/$STACK_NAME/stack.env"
+EDGE_ROUTE_FILE="$EDGE_ROUTES_DIR/$STACK_NAME.caddy"
+
+escape_env_value() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+write_env_var() {
+  local name="$1"
+  local value="${!name:-}"
+
+  if [ -n "$value" ]; then
+    printf '%s="%s"\n' "$name" "$(escape_env_value "$value")" >> "$STACK_ENV_FILE"
+  fi
+}
+
+: > "$STACK_ENV_FILE"
+
+for env_name in \
+  STACK_NAME \
+  STACK_ENV \
+  STACK_VERSION \
+  STACK_ROUTER_PORT \
+  NEXT_HOST \
+  CUSTOM_HOST \
+  TANSTACK_HOST \
+  PREVIEW_ID \
+  OBS_NEXTJS_IMAGE \
+  OBS_EXPRESS_IMAGE \
+  OBS_GRAPHQL_IMAGE \
+  OBS_TANSTACK_IMAGE \
+  ACME_EMAIL \
+  DD_API_KEY \
+  DD_SITE \
+  DD_LOGS_ENABLED \
+  DD_OTLP_CONFIG_LOGS_ENABLED \
+  HONEYCOMB_ENDPOINT \
+  HONEYCOMB_API_KEY \
+  GRAFANA_OTLP_ENDPOINT \
+  GRAFANA_OTLP_AUTH \
+  SENTRY_OTLP_ENDPOINT \
+  SENTRY_AUTH \
+  SENTRY_AUTH_TOKEN \
+  NEXT_PUBLIC_SENTRY_DSN \
+  NEXT_PUBLIC_STATSIG_CLIENT_KEY \
+  NEXT_PUBLIC_DATADOG_CLIENT_TOKEN \
+  NEXT_PUBLIC_DATADOG_APP_ID \
+  VITE_DATADOG_CLIENT_TOKEN \
+  VITE_DATADOG_APP_ID; do
+  write_env_var "$env_name"
+done
+
+cat > "$EDGE_ROUTE_FILE" <<EOF
+${NEXT_HOST}, ${CUSTOM_HOST}, ${TANSTACK_HOST} {
+  reverse_proxy 127.0.0.1:${STACK_ROUTER_PORT}
+}
+EOF
+
+export STACK_ENV_FILE EDGE_ROUTES_DIR
+
+docker compose \
+  --env-file "$STACK_ENV_FILE" \
+  -f "$ROOT_DIR/deploy/compose/edge.yaml" \
+  up -d
+
+docker compose \
+  --env-file "$STACK_ENV_FILE" \
+  -f "$ROOT_DIR/deploy/compose/stack.yaml" \
+  -p "$STACK_NAME" \
+  up -d
+
+printf 'Deployed stack %s on router port %s\n' "$STACK_NAME" "$STACK_ROUTER_PORT"

--- a/scripts/destroy-preview.sh
+++ b/scripts/destroy-preview.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+STACK_ROOT=${STACK_ROOT:-/srv/obs/stacks}
+EDGE_ROUTES_DIR=${EDGE_ROUTES_DIR:-/srv/obs/edge/routes}
+
+if [ -z "${PR_NUMBER:-}" ]; then
+  printf 'Missing required environment variable: PR_NUMBER\n' >&2
+  exit 1
+fi
+
+STACK_NAME="obs-pr-${PR_NUMBER}"
+STACK_ENV_FILE="$STACK_ROOT/$STACK_NAME/stack.env"
+EDGE_ROUTE_FILE="$EDGE_ROUTES_DIR/$STACK_NAME.caddy"
+
+if [ -f "$STACK_ENV_FILE" ]; then
+  docker compose \
+    --env-file "$STACK_ENV_FILE" \
+    -f "$ROOT_DIR/deploy/compose/stack.yaml" \
+    -p "$STACK_NAME" \
+    down --remove-orphans --volumes
+fi
+
+rm -f "$STACK_ENV_FILE" "$EDGE_ROUTE_FILE"
+rm -rf "$STACK_ROOT/$STACK_NAME"
+
+printf 'Destroyed preview stack %s\n' "$STACK_NAME"


### PR DESCRIPTION
## Summary
- add Dockerfiles, Compose configs, Caddy routing, and host automation for a single Vultr VM that runs the main app and PR previews as isolated stacks
- add Terraform, cloud-init, deploy scripts, and GitHub workflows so main and preview deploys only happen after the CI workflow passes
- make public GraphQL URL resolution runtime-aware and document the new Datadog, domain, and SQLite deployment model

## Testing
- npm run build
- npm run type-check
- bash -n scripts/deploy-stack.sh scripts/deploy-preview.sh scripts/destroy-preview.sh scripts/backup-sqlite.sh
- docker compose --env-file <generated stack env> -f deploy/compose/edge.yaml config
- docker compose --env-file <generated stack env> -f deploy/compose/stack.yaml config