### PR TITLE
fix: run Render apps via npm scripts from app workdir

### DIFF
--- a/deploy/render/app-with-datadog/Dockerfile
+++ b/deploy/render/app-with-datadog/Dockerfile
@@ -37,6 +37,8 @@ ENV HOST_PROC=/proc
 ENV PATH=/app/node_modules/.bin:/opt/node/bin:/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 COPY --from=builder /usr/local/bin/node /opt/node/bin/node
+COPY --from=builder /usr/local/lib/node_modules/npm /opt/node/lib/node_modules/npm
+RUN ln -s /opt/node/lib/node_modules/npm/bin/npm-cli.js /opt/node/bin/npm
 COPY --from=builder /app /app
 
 RUN chmod +x \

--- a/deploy/render/app-with-datadog/run-app.sh
+++ b/deploy/render/app-with-datadog/run-app.sh
@@ -6,5 +6,10 @@ if [[ -z "${APP_START_COMMAND:-}" ]]; then
   exit 1
 fi
 
-cd /app
+if [[ -z "${APP_WORKDIR:-}" ]]; then
+  echo "APP_WORKDIR must be set"
+  exit 1
+fi
+
+cd "/app/${APP_WORKDIR}"
 exec /bin/bash -c "$APP_START_COMMAND"

--- a/render.yaml
+++ b/render.yaml
@@ -12,8 +12,10 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: APP_WORKDIR
+        value: apps/graphql-server
       - key: APP_START_COMMAND
-        value: node apps/graphql-server/dist/index.js
+        value: npm run start
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE
@@ -56,8 +58,10 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: APP_WORKDIR
+        value: apps/express-server
       - key: APP_START_COMMAND
-        value: node apps/express-server/dist/index.js
+        value: npm run start
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE
@@ -100,8 +104,10 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: APP_WORKDIR
+        value: apps/nextjs-app
       - key: APP_START_COMMAND
-        value: next start --hostname 0.0.0.0 --port $PORT
+        value: npm run start
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE
@@ -158,8 +164,10 @@ services:
         value: 10000
       - key: CUSTOM_SERVER
         value: "true"
+      - key: APP_WORKDIR
+        value: apps/nextjs-app
       - key: APP_START_COMMAND
-        value: tsx apps/nextjs-app/server.ts
+        value: npm run start:custom
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE
@@ -214,8 +222,10 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: APP_WORKDIR
+        value: apps/tanstack-start
       - key: APP_START_COMMAND
-        value: node apps/tanstack-start/.output/server/index.mjs
+        value: npm run start
       - key: DD_API_KEY
         sync: false
       - key: DD_SITE


### PR DESCRIPTION
## Summary
- run each Render service via the app's own `npm run start` script (including `start:custom` for the Next.js custom server) instead of hard-coded node/next/tsx invocations in `render.yaml`, so start commands stay in sync with the app-level scripts
- add an `APP_WORKDIR` env var per service and have the shared Datadog runtime entrypoint `cd` into `/app/${APP_WORKDIR}` before executing the start command, so `npm run start` resolves against the correct workspace
- install the host Node image's bundled `npm` into the Datadog app image so `npm run start` is available at runtime

## Testing
- Not run (not requested)