### PR TITLE
fix: speed up CI dependency setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,12 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-typecheck:
-    name: Lint & Type Check
+  ci:
+    name: CI
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
 
     steps:
       - name: Checkout code
@@ -21,32 +24,25 @@ jobs:
           node-version: "24"
           cache: "npm"
 
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node24-playwright-v1.58.2-noble-${{ hashFiles('package-lock.json', 'patches/**/*') }}
+
       - name: Install dependencies
-        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --no-audit
 
       - name: Run lint
         run: npm run lint
 
       - name: Run type-check
         run: npm run type-check
-
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: lint-and-typecheck
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Generate SSL certificates
         run: bash scripts/generate-cert.sh
@@ -86,9 +82,6 @@ jobs:
           SENTRY_AUTH=${{ secrets.SENTRY_AUTH }}
           NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
           EOF
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
 
       - name: Build all services
         run: npm run build


### PR DESCRIPTION
## Summary
- run the CI workflow in the Playwright container so browser binaries and system deps are already available
- cache workspace node_modules using the lockfile and patch set so warm runs can skip repeated npm ci work
- collapse the serialized lint/type-check and e2e jobs into one CI job so dependency installation happens once per workflow