### PR TITLE
feat: expand structured logging across services

### DIFF
--- a/apps/express-server/src/error-middleware.ts
+++ b/apps/express-server/src/error-middleware.ts
@@ -2,9 +2,21 @@ import type { Request, Response, NextFunction } from "express";
 import { trace, SpanStatusCode } from "@opentelemetry/api";
 import { logger } from "./otel";
 
+function getRoutePath(route: unknown): string | undefined {
+  if (
+    route &&
+    typeof route === "object" &&
+    "path" in route &&
+    typeof route.path === "string"
+  ) {
+    return route.path;
+  }
+  return undefined;
+}
+
 export function errorHandler(
   err: Error,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
@@ -12,8 +24,11 @@ export function errorHandler(
 
   logger.error("Unhandled error", {
     err,
-    method: _req.method,
-    path: _req.path,
+    "http.method": req.method,
+    "http.path": req.path,
+    "http.route": getRoutePath(req.route),
+    "http.user_agent": req.get("user-agent"),
+    "http.query": req.query,
   });
 
   activeSpan?.recordException(err);

--- a/apps/express-server/src/request-logger.ts
+++ b/apps/express-server/src/request-logger.ts
@@ -1,6 +1,18 @@
 import type { Request, Response, NextFunction } from "express";
 import { logger } from "./otel";
 
+function getRoutePath(route: unknown): string | undefined {
+  if (
+    route &&
+    typeof route === "object" &&
+    "path" in route &&
+    typeof route.path === "string"
+  ) {
+    return route.path;
+  }
+  return undefined;
+}
+
 export function requestLogger(
   req: Request,
   res: Response,
@@ -10,11 +22,18 @@ export function requestLogger(
 
   res.on("finish", () => {
     const duration = Date.now() - start;
+    const contentLength = res.getHeader("content-length");
     const log = {
-      method: req.method,
-      path: req.path,
-      statusCode: res.statusCode,
-      durationMs: duration,
+      "http.method": req.method,
+      "http.path": req.path,
+      "http.route": getRoutePath(req.route),
+      "http.status_code": res.statusCode,
+      "http.duration_ms": duration,
+      "http.user_agent": req.get("user-agent"),
+      "http.response_content_length":
+        typeof contentLength === "string"
+          ? parseInt(contentLength, 10)
+          : undefined,
     };
 
     if (res.statusCode >= 500) {

--- a/apps/express-server/src/routes/batch-nutrition.ts
+++ b/apps/express-server/src/routes/batch-nutrition.ts
@@ -10,10 +10,14 @@ const router = Router();
 
 router.post("/batch/nutrition", async (req: Request, res: Response) => {
   const activeSpan = trace.getActiveSpan();
+  const requestStart = Date.now();
   const parsed = batchNutritionSchema.safeParse(req.body);
 
   if (!parsed.success) {
-    logger.warn("Batch nutrition validation failed", { err: parsed.error });
+    logger.warn("Batch nutrition validation failed", {
+      err: parsed.error,
+      "batch_nutrition.issue_count": parsed.error.issues.length,
+    });
     activeSpan?.recordException(parsed.error);
     return res.status(400).json({ error: parsed.error.issues });
   }
@@ -25,6 +29,12 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
     "batch_nutrition.recipe_count": recipeIds.length,
   });
 
+  logger.info("Batch nutrition request received", {
+    "batch_nutrition.recipe_ids": recipeIds,
+    "batch_nutrition.recipe_count": recipeIds.length,
+  });
+
+  const graphqlStart = Date.now();
   const { recipes: allRecipes } = await graphqlRequest<{
     recipes: GraphQLRecipe[];
   }>(`
@@ -44,10 +54,23 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => recipeIds.includes(r.id));
+  const foundIds = selectedRecipes.map((r) => r.id);
+  const missingIds = recipeIds.filter((id) => !foundIds.includes(id));
+
   logger.info("Batch nutrition recipes fetched from GraphQL", {
-    requested: recipeIds.length,
-    found: selectedRecipes.length,
+    "batch_nutrition.requested_count": recipeIds.length,
+    "batch_nutrition.found_count": selectedRecipes.length,
+    "batch_nutrition.missing_count": missingIds.length,
+    "graphql.duration_ms": Date.now() - graphqlStart,
   });
+
+  if (missingIds.length > 0) {
+    logger.warn("Batch nutrition has missing recipes", {
+      "batch_nutrition.requested_ids": recipeIds,
+      "batch_nutrition.missing_ids": missingIds,
+      "batch_nutrition.found_ids": foundIds,
+    });
+  }
 
   // Calculate nutrition for each recipe
   const recipeNutritionData: RecipeNutrition[] = selectedRecipes.map(
@@ -92,6 +115,19 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
   const calories = recipeNutritionData.map((r) => r.calories);
   const avgCalories = totalCalories / recipeNutritionData.length;
   const avgProtein = totalProtein / recipeNutritionData.length;
+  const minCalories = Math.min(...calories);
+  const maxCalories = Math.max(...calories);
+
+  logger.info("Batch nutrition aggregated", {
+    "batch_nutrition.recipes_analyzed": recipeNutritionData.length,
+    "batch_nutrition.total_calories": totalCalories,
+    "batch_nutrition.total_protein": totalProtein,
+    "batch_nutrition.total_fat": totalFat,
+    "batch_nutrition.total_carbs": totalCarbs,
+    "batch_nutrition.avg_calories_per_recipe": avgCalories,
+    "batch_nutrition.calories_range_min": minCalories,
+    "batch_nutrition.calories_range_max": maxCalories,
+  });
 
   activeSpan?.setAttributes({
     "batch_nutrition.recipe_titles": recipeTitles,
@@ -102,8 +138,15 @@ router.post("/batch/nutrition", async (req: Request, res: Response) => {
     "batch_nutrition.total_carbs": totalCarbs,
     "batch_nutrition.avg_calories_per_recipe": avgCalories,
     "batch_nutrition.avg_protein_per_recipe": avgProtein,
-    "batch_nutrition.calories_range_min": Math.min(...calories),
-    "batch_nutrition.calories_range_max": Math.max(...calories),
+    "batch_nutrition.calories_range_min": minCalories,
+    "batch_nutrition.calories_range_max": maxCalories,
+  });
+
+  logger.info("Batch nutrition analysis complete", {
+    "batch_nutrition.recipes_analyzed": recipeNutritionData.length,
+    "batch_nutrition.total_calories": totalCalories,
+    "batch_nutrition.avg_calories_per_recipe": avgCalories,
+    "batch_nutrition.duration_ms": Date.now() - requestStart,
   });
 
   res.json({

--- a/apps/express-server/src/routes/meal-plan.ts
+++ b/apps/express-server/src/routes/meal-plan.ts
@@ -9,9 +9,14 @@ const router = Router();
 
 router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
   const activeSpan = trace.getActiveSpan();
+  const requestStart = Date.now();
   const { recipeIds } = req.query;
 
   if (!recipeIds || typeof recipeIds !== "string") {
+    logger.warn("Meal plan missing recipeIds query parameter", {
+      "meal_plan.query_param_present": Boolean(recipeIds),
+      "meal_plan.query_param_type": typeof recipeIds,
+    });
     return res
       .status(400)
       .json({ error: "recipeIds query parameter is required" });
@@ -24,6 +29,12 @@ router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
     "meal_plan.recipe_count": idsArray.length,
   });
 
+  logger.info("Meal plan request received", {
+    "meal_plan.recipe_ids": idsArray,
+    "meal_plan.recipe_count": idsArray.length,
+  });
+
+  const graphqlStart = Date.now();
   const { recipes: allRecipes } = await graphqlRequest<{
     recipes: GraphQLRecipe[];
   }>(`
@@ -43,10 +54,23 @@ router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => idsArray.includes(r.id));
+  const foundIds = selectedRecipes.map((r) => r.id);
+  const missingIds = idsArray.filter((id) => !foundIds.includes(id));
+
   logger.info("Meal plan recipes fetched from GraphQL", {
-    requested: idsArray.length,
-    found: selectedRecipes.length,
+    "meal_plan.requested_count": idsArray.length,
+    "meal_plan.found_count": selectedRecipes.length,
+    "meal_plan.missing_count": missingIds.length,
+    "graphql.duration_ms": Date.now() - graphqlStart,
   });
+
+  if (missingIds.length > 0) {
+    logger.warn("Meal plan has missing recipes", {
+      "meal_plan.requested_ids": idsArray,
+      "meal_plan.missing_ids": missingIds,
+      "meal_plan.found_ids": foundIds,
+    });
+  }
 
   // Calculate cost for each recipe
   const recipeCosts = selectedRecipes.map((recipe) => {
@@ -72,6 +96,14 @@ router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
   const maxCost = Math.max(...costs);
   const costPerDay = totalWeeklyCost / 7;
 
+  logger.info("Meal plan costs calculated", {
+    "meal_plan.meal_count": recipeCosts.length,
+    "meal_plan.total_weekly_cost": totalWeeklyCost,
+    "meal_plan.average_meal_cost": averageMealCost,
+    "meal_plan.cost_range_min": minCost,
+    "meal_plan.cost_range_max": maxCost,
+  });
+
   activeSpan?.setAttributes({
     "meal_plan.recipe_titles": recipeTitles,
     "meal_plan.total_weekly_cost": totalWeeklyCost,
@@ -80,6 +112,14 @@ router.get("/meal-plan/estimate", async (req: Request, res: Response) => {
     "meal_plan.cost_range_min": minCost,
     "meal_plan.cost_range_max": maxCost,
     "meal_plan.meal_count": recipeCosts.length,
+  });
+
+  logger.info("Meal plan estimate generated", {
+    "meal_plan.total_weekly_cost": totalWeeklyCost,
+    "meal_plan.cost_per_day": costPerDay,
+    "meal_plan.average_meal_cost": averageMealCost,
+    "meal_plan.meal_count": recipeCosts.length,
+    "meal_plan.duration_ms": Date.now() - requestStart,
   });
 
   res.json({

--- a/apps/express-server/src/routes/shopping-list.ts
+++ b/apps/express-server/src/routes/shopping-list.ts
@@ -10,23 +10,35 @@ const router = Router();
 
 router.post("/shopping-list/generate", async (req: Request, res: Response) => {
   const activeSpan = trace.getActiveSpan();
+  const requestStart = Date.now();
   const parsed = shoppingListSchema.safeParse(req.body);
 
   if (!parsed.success) {
-    logger.warn("Shopping list validation failed", { err: parsed.error });
+    logger.warn("Shopping list validation failed", {
+      err: parsed.error,
+      "shopping_list.issue_count": parsed.error.issues.length,
+    });
     activeSpan?.recordException(parsed.error);
     return res.status(400).json({ error: parsed.error.issues });
   }
 
   const { recipeIds, servings = {} } = parsed.data;
+  const hasCustomServings = Object.keys(servings).length > 0;
 
   // Capture inputs
   activeSpan?.setAttributes({
     "shopping_list.recipe_ids": JSON.stringify(recipeIds),
     "shopping_list.recipe_count": recipeIds.length,
-    "shopping_list.has_custom_servings": Object.keys(servings).length > 0,
+    "shopping_list.has_custom_servings": hasCustomServings,
   });
 
+  logger.info("Shopping list request received", {
+    "shopping_list.recipe_ids": recipeIds,
+    "shopping_list.recipe_count": recipeIds.length,
+    "shopping_list.has_custom_servings": hasCustomServings,
+  });
+
+  const graphqlStart = Date.now();
   const { recipes: allRecipes } = await graphqlRequest<{
     recipes: GraphQLRecipe[];
   }>(`
@@ -46,10 +58,23 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
     }
   `);
   const selectedRecipes = allRecipes.filter((r) => recipeIds.includes(r.id));
+  const foundIds = selectedRecipes.map((r) => r.id);
+  const missingIds = recipeIds.filter((id) => !foundIds.includes(id));
+
   logger.info("Shopping list recipes fetched from GraphQL", {
-    requested: recipeIds.length,
-    found: selectedRecipes.length,
+    "shopping_list.requested_count": recipeIds.length,
+    "shopping_list.found_count": selectedRecipes.length,
+    "shopping_list.missing_count": missingIds.length,
+    "graphql.duration_ms": Date.now() - graphqlStart,
   });
+
+  if (missingIds.length > 0) {
+    logger.warn("Shopping list has missing recipes", {
+      "shopping_list.requested_ids": recipeIds,
+      "shopping_list.missing_ids": missingIds,
+      "shopping_list.found_ids": foundIds,
+    });
+  }
 
   activeSpan?.setAttributes({
     "shopping_list.recipes_found": selectedRecipes.length,
@@ -62,10 +87,12 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
     { name: string; unit: string; quantity: number }
   >();
 
+  let totalIngredientEntries = 0;
   selectedRecipes.forEach((recipe) => {
     const recipeServings = servings[recipe.id] ?? 1;
 
     recipe.ingredients.forEach(({ ingredient, quantity }) => {
+      totalIngredientEntries += 1;
       const existing = ingredientMap.get(ingredient.id);
       const scaledQuantity = quantity * recipeServings;
 
@@ -81,15 +108,27 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
     });
   });
 
+  logger.info("Shopping list ingredients aggregated", {
+    "shopping_list.unique_ingredients": ingredientMap.size,
+    "shopping_list.total_ingredient_entries": totalIngredientEntries,
+    "shopping_list.recipe_count": selectedRecipes.length,
+  });
+
   // Add pricing and stock info
   const shoppingList: ShoppingListItem[] = [];
   let totalCost = 0;
   const outOfStock: string[] = [];
+  const outOfStockIds: string[] = [];
+  let pricedCount = 0;
 
   ingredientMap.forEach((item, ingredientId) => {
     const pricePerUnit = ingredientPrices[ingredientId] ?? 0;
     const inventory = ingredientInventory[ingredientId];
     const itemTotalCost = pricePerUnit * item.quantity;
+
+    if (pricePerUnit > 0) {
+      pricedCount += 1;
+    }
 
     shoppingList.push({
       ingredientId,
@@ -105,8 +144,26 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
 
     if (!inventory?.inStock) {
       outOfStock.push(item.name);
+      outOfStockIds.push(ingredientId);
     }
   });
+
+  const inStockCount = shoppingList.length - outOfStock.length;
+
+  logger.info("Shopping list prices and inventory applied", {
+    "shopping_list.ingredient_count": shoppingList.length,
+    "shopping_list.priced_count": pricedCount,
+    "shopping_list.in_stock_count": inStockCount,
+    "shopping_list.out_of_stock_count": outOfStock.length,
+  });
+
+  if (outOfStock.length > 0) {
+    logger.warn("Shopping list has out-of-stock items", {
+      "shopping_list.out_of_stock_names": outOfStock,
+      "shopping_list.out_of_stock_ids": outOfStockIds,
+      "shopping_list.out_of_stock_count": outOfStock.length,
+    });
+  }
 
   // Calculate additional metrics
   const recipeTitles = selectedRecipes.map((r) => r.title).join(",");
@@ -131,6 +188,17 @@ router.post("/shopping-list/generate", async (req: Request, res: Response) => {
     "shopping_list.most_expensive_ingredient": mostExpensiveItem?.name,
     "shopping_list.most_expensive_ingredient_cost":
       mostExpensiveItem?.totalCost,
+  });
+
+  logger.info("Shopping list generated", {
+    "shopping_list.total_cost": totalCost,
+    "shopping_list.cost_per_serving": costPerServing,
+    "shopping_list.total_items": shoppingList.length,
+    "shopping_list.out_of_stock_count": outOfStock.length,
+    "shopping_list.most_expensive_ingredient": mostExpensiveItem?.name,
+    "shopping_list.most_expensive_ingredient_cost":
+      mostExpensiveItem?.totalCost,
+    "shopping_list.duration_ms": Date.now() - requestStart,
   });
 
   res.json({

--- a/apps/graphql-server/src/index.ts
+++ b/apps/graphql-server/src/index.ts
@@ -10,16 +10,28 @@ import { resolvers } from "./resolvers/index.js";
 const loggingPlugin = {
   async requestDidStart({ request }) {
     const operationName = request.operationName ?? "anonymous";
-    logger.info("GraphQL operation started", { operationName });
+    const variableCount = request.variables
+      ? Object.keys(request.variables).length
+      : 0;
+    logger.info("GraphQL operation started", {
+      "graphql.operation_name": operationName,
+      "graphql.variable_count": variableCount,
+    });
+
+    let operationType: string | undefined;
 
     return {
+      async didResolveOperation({ operation }) {
+        operationType = operation?.operation;
+      },
       async didEncounterErrors({ errors }) {
         for (const err of errors) {
           logger.error("GraphQL error", {
-            operationName,
+            "graphql.operation_name": operationName,
+            "graphql.operation_type": operationType,
             err,
-            path: err.path,
-            code: err.extensions.code,
+            "graphql.error.path": err.path,
+            "graphql.error.code": err.extensions.code,
           });
         }
       },
@@ -29,8 +41,9 @@ const loggingPlugin = {
             ? (response.body.singleResult.errors?.length ?? 0)
             : 0;
         logger.info("GraphQL operation completed", {
-          operationName,
-          errorCount,
+          "graphql.operation_name": operationName,
+          "graphql.operation_type": operationType,
+          "graphql.error_count": errorCount,
         });
       },
     };
@@ -54,11 +67,17 @@ app.use((req, res, next) => {
 
   res.on("finish", () => {
     const durationMs = Date.now() - start;
+    const contentLength = res.getHeader("content-length");
     const log = {
-      method: req.method,
-      path: req.path,
-      statusCode: res.statusCode,
-      durationMs,
+      "http.method": req.method,
+      "http.path": req.path,
+      "http.status_code": res.statusCode,
+      "http.duration_ms": durationMs,
+      "http.user_agent": req.get("user-agent"),
+      "http.response_content_length":
+        typeof contentLength === "string"
+          ? parseInt(contentLength, 10)
+          : undefined,
     };
 
     if (res.statusCode >= 500) {

--- a/apps/graphql-server/src/resolvers/mutations.ts
+++ b/apps/graphql-server/src/resolvers/mutations.ts
@@ -7,6 +7,29 @@ import {
   ingredients,
   incrementRecipeIdCounter,
 } from "../data/index.js";
+import { logger } from "../otel.js";
+
+function diffRecipeFields(
+  previous: Recipe,
+  next: Omit<Recipe, "id">,
+): string[] {
+  const changed: string[] = [];
+  const keys: (keyof Omit<Recipe, "id">)[] = [
+    "title",
+    "description",
+    "prepTime",
+    "cookTime",
+    "difficulty",
+    "servings",
+    "categoryId",
+  ];
+  for (const key of keys) {
+    if (previous[key] !== next[key]) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}
 
 export const Mutation = {
   createRecipe: (
@@ -59,6 +82,16 @@ export const Mutation = {
       "recipe.ingredient_categories": ingredientCategories,
     });
 
+    logger.info("Recipe created", {
+      "recipe.id": newRecipe.id,
+      "recipe.title": newRecipe.title,
+      "recipe.category": category?.name,
+      "recipe.difficulty": newRecipe.difficulty,
+      "recipe.servings": newRecipe.servings,
+      "recipe.ingredient_count": input.ingredients.length,
+      "recipe.ingredient_categories": ingredientCategories,
+    });
+
     return newRecipe;
   },
 
@@ -73,8 +106,14 @@ export const Mutation = {
     });
 
     if (index === -1) {
+      logger.warn("Recipe update target not found", {
+        "recipe.id": id,
+      });
       return null;
     }
+
+    const previous = recipes[index];
+    const changedFields = diffRecipeFields(previous, recipe);
 
     const updatedRecipe = { id, ...recipe };
     recipes[index] = updatedRecipe;
@@ -84,6 +123,12 @@ export const Mutation = {
     activeSpan?.setAttributes({
       "recipe.title": updatedRecipe.title,
       "recipe.category": category?.name,
+    });
+
+    logger.info("Recipe updated", {
+      "recipe.id": id,
+      "recipe.changed_fields": changedFields,
+      "recipe.changed_field_count": changedFields.length,
     });
 
     return recipes[index];
@@ -97,6 +142,9 @@ export const Mutation = {
     });
 
     if (index === -1) {
+      logger.warn("Recipe deletion target not found", {
+        "recipe.id": id,
+      });
       return false;
     }
 
@@ -113,6 +161,13 @@ export const Mutation = {
     activeSpan?.setAttributes({
       "recipe.title": recipe.title,
       "recipe.category": category?.name,
+    });
+
+    logger.info("Recipe deleted", {
+      "recipe.id": id,
+      "recipe.title": recipe.title,
+      "recipe.category": category?.name,
+      "recipe.ingredient_links_removed": ingIndexes.length,
     });
 
     return true;

--- a/apps/graphql-server/src/resolvers/queries.ts
+++ b/apps/graphql-server/src/resolvers/queries.ts
@@ -9,6 +9,7 @@ import {
 } from "../data/index.js";
 import { getOperationSpan } from "../utils/otel.js";
 import { pricesResponseSchema, nutritionResponseSchema } from "../schemas.js";
+import { logger } from "../otel.js";
 
 export const Query = {
   recipe: (_: unknown, { id }: { id: string }) => {
@@ -22,6 +23,7 @@ export const Query = {
   recipeWithCost: async (_: unknown, { id }: { id: string }) => {
     const activeSpan = trace.getActiveSpan();
     const operationSpan = getOperationSpan();
+    const resolverStart = Date.now();
 
     activeSpan?.setAttributes({
       "recipe.id": id,
@@ -32,10 +34,17 @@ export const Query = {
       "resolver.recipe_with_cost.includes_pricing": true,
     });
 
+    logger.info("Resolving recipeWithCost", {
+      "recipe.id": id,
+    });
+
     const recipe = recipes.find((r) => r.id === id);
     if (!recipe) {
       activeSpan?.setAttribute("recipe.found", false);
       operationSpan?.setAttribute("resolver.recipe_with_cost.found", false);
+      logger.warn("Recipe not found in recipeWithCost", {
+        "recipe.id": id,
+      });
       return null;
     }
 
@@ -59,11 +68,26 @@ export const Query = {
       "recipe.ingredient_ids": ingredientIds.join(","),
     });
 
+    logger.info("Fetching ingredient prices from Express", {
+      "recipe.id": id,
+      "recipe.title": recipe.title,
+      "recipe.ingredient_count": recipeIngs.length,
+      "recipe.ingredient_ids": ingredientIds,
+    });
+
+    const expressStart = Date.now();
     const response = await fetch(
       `${getExpressUrl()}/ingredients/prices?ids=${ingredientIds.join(",")}`,
     );
     const pricesResult = pricesResponseSchema.safeParse(await response.json());
     const prices = pricesResult.success ? pricesResult.data : {};
+
+    logger.info("Fetched ingredient prices from Express", {
+      "recipe.id": id,
+      "pricing.ingredient_count": Object.keys(prices).length,
+      "pricing.parse_success": pricesResult.success,
+      "express.duration_ms": Date.now() - expressStart,
+    });
 
     const ingredientCosts: IngredientCost[] = recipeIngs.flatMap((ri) => {
       const ingredient = ingredients.find((i) => i.id === ri.ingredientId);
@@ -101,6 +125,15 @@ export const Query = {
       "resolver.recipe_with_cost.ingredient_count": ingredientCosts.length,
     });
 
+    logger.info("Resolved recipeWithCost", {
+      "recipe.id": id,
+      "recipe.title": recipe.title,
+      "recipe.total_cost": totalCost,
+      "recipe.cost_per_serving": costPerServing,
+      "recipe.ingredient_count": ingredientCosts.length,
+      "resolver.duration_ms": Date.now() - resolverStart,
+    });
+
     return {
       ...recipe,
       ingredientCosts,
@@ -110,14 +143,22 @@ export const Query = {
 
   recipeWithNutrition: async (_: unknown, { id }: { id: string }) => {
     const activeSpan = trace.getActiveSpan();
+    const resolverStart = Date.now();
 
     activeSpan?.setAttributes({
+      "recipe.id": id,
+    });
+
+    logger.info("Resolving recipeWithNutrition", {
       "recipe.id": id,
     });
 
     const recipe = recipes.find((r) => r.id === id);
     if (!recipe) {
       activeSpan?.setAttribute("recipe.found", false);
+      logger.warn("Recipe not found in recipeWithNutrition", {
+        "recipe.id": id,
+      });
       return null;
     }
 
@@ -140,6 +181,13 @@ export const Query = {
       "nutrition.parallel_requests": recipeIngs.length,
     });
 
+    logger.info("Fetching nutrition data from Express in parallel", {
+      "recipe.id": id,
+      "recipe.title": recipe.title,
+      "nutrition.parallel_requests": recipeIngs.length,
+    });
+
+    const expressStart = Date.now();
     const nutritionPromises = recipeIngs.map(async (ri) => {
       const response = await fetch(
         `${getExpressUrl()}/nutrition/ingredient/${ri.ingredientId}`,
@@ -158,6 +206,13 @@ export const Query = {
     });
 
     const nutritionData = await Promise.all(nutritionPromises);
+
+    logger.info("Fetched nutrition data from Express", {
+      "recipe.id": id,
+      "nutrition.parallel_requests": recipeIngs.length,
+      "nutrition.responses_received": nutritionData.length,
+      "express.duration_ms": Date.now() - expressStart,
+    });
 
     const totalNutrition = nutritionData.reduce(
       (sum, n) => ({
@@ -183,6 +238,15 @@ export const Query = {
       "nutrition.protein_per_serving": proteinPerServing,
       "nutrition.fat_per_serving": fatPerServing,
       "nutrition.carbs_per_serving": carbsPerServing,
+    });
+
+    logger.info("Resolved recipeWithNutrition", {
+      "recipe.id": id,
+      "recipe.title": recipe.title,
+      "nutrition.total_calories": totalNutrition.calories,
+      "nutrition.calories_per_serving": caloriesPerServing,
+      "nutrition.protein_per_serving": proteinPerServing,
+      "resolver.duration_ms": Date.now() - resolverStart,
     });
 
     return {

--- a/apps/nextjs-app/src/app/batch-nutrition/page.tsx
+++ b/apps/nextjs-app/src/app/batch-nutrition/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
+import { logger } from "@/otel";
 
 const recipeNutritionSchema = z.object({
   recipeId: z.string(),
@@ -24,7 +25,9 @@ type BatchNutritionResponse = z.infer<typeof batchNutritionResponseSchema>;
 
 async function getBatchNutrition(
   recipeIds: string[],
+  isDefault: boolean,
 ): Promise<BatchNutritionResponse> {
+  const fetchStart = Date.now();
   const response = await fetch(`${getExpressUrl()}/batch/nutrition`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -48,6 +51,15 @@ async function getBatchNutrition(
     throw new Error("Invalid response format");
   }
 
+  logger.info("Batch nutrition page fetched", {
+    "batch_nutrition.recipe_ids": recipeIds,
+    "batch_nutrition.recipe_count": recipeIds.length,
+    "batch_nutrition.using_default_ids": isDefault,
+    "batch_nutrition.recipes_analyzed": result.data.count,
+    "http.status_code": response.status,
+    "http.duration_ms": Date.now() - fetchStart,
+  });
+
   return result.data;
 }
 
@@ -57,8 +69,9 @@ export default async function BatchNutritionPage({
   searchParams: Promise<{ ids?: string }>;
 }) {
   const params = await searchParams;
+  const hasCustomIds = Boolean(params.ids);
   const ids = params.ids ? params.ids.split(",") : ["1", "2", "3"];
-  const nutritionData = await getBatchNutrition(ids);
+  const nutritionData = await getBatchNutrition(ids, !hasCustomIds);
 
   const totals = nutritionData.recipes.reduce(
     (acc, recipe) => ({

--- a/apps/nextjs-app/src/app/meal-planner/page.tsx
+++ b/apps/nextjs-app/src/app/meal-planner/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
+import { logger } from "@/otel";
 
 const recipeCostSchema = z.object({
   recipeId: z.string(),
@@ -23,7 +24,9 @@ type MealPlanEstimate = z.infer<typeof mealPlanEstimateSchema>;
 
 async function getMealPlanEstimate(
   recipeIds: string[],
+  isDefault: boolean,
 ): Promise<MealPlanEstimate> {
+  const fetchStart = Date.now();
   const response = await fetch(
     `${getExpressUrl()}/meal-plan/estimate?recipeIds=${recipeIds.join(",")}`,
     {
@@ -47,6 +50,17 @@ async function getMealPlanEstimate(
     throw new Error("Invalid response format");
   }
 
+  logger.info("Meal planner page fetched", {
+    "meal_plan.recipe_ids": recipeIds,
+    "meal_plan.recipe_count": recipeIds.length,
+    "meal_plan.using_default_ids": isDefault,
+    "meal_plan.meal_count": result.data.mealCount,
+    "meal_plan.total_weekly_cost": result.data.totalWeeklyCost,
+    "meal_plan.average_meal_cost": result.data.averageMealCost,
+    "http.status_code": response.status,
+    "http.duration_ms": Date.now() - fetchStart,
+  });
+
   return result.data;
 }
 
@@ -66,10 +80,11 @@ export default async function MealPlannerPage({
   searchParams: Promise<{ ids?: string }>;
 }) {
   const params = await searchParams;
+  const hasCustomIds = Boolean(params.ids);
   const ids = params.ids
     ? params.ids.split(",")
     : ["1", "2", "3", "1", "2", "3", "1"];
-  const mealPlan = await getMealPlanEstimate(ids);
+  const mealPlan = await getMealPlanEstimate(ids, !hasCustomIds);
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">

--- a/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
+++ b/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { graphqlRequest } from "@obs-playground/graphql-client";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
+import { logger } from "@/otel";
 
 type Ingredient = {
   id: string;
@@ -119,6 +120,7 @@ export default async function FullRecipePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const pageStart = Date.now();
 
   // Fetch recipe first, then prices for its ingredients
   const recipe = await getRecipe(id);
@@ -127,6 +129,10 @@ export default async function FullRecipePage({
     : {};
 
   if (!recipe) {
+    logger.warn("Full recipe page recipe not found", {
+      "recipe.id": id,
+      "http.duration_ms": Date.now() - pageStart,
+    });
     return (
       <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">
         <div className="mx-auto max-w-4xl px-4 py-12">
@@ -178,6 +184,19 @@ export default async function FullRecipePage({
   );
 
   const outOfStockItems = ingredientData.filter((item) => !item.stock.inStock);
+
+  logger.info("Full recipe page fetched", {
+    "recipe.id": id,
+    "recipe.title": recipe.title,
+    "recipe.difficulty": recipe.difficulty,
+    "recipe.servings": recipe.servings,
+    "recipe.ingredient_count": recipe.ingredients.length,
+    "recipe.total_cost": totalCost,
+    "recipe.cost_per_serving": totalCost / recipe.servings,
+    "recipe.total_calories": totalNutrition.calories,
+    "recipe.out_of_stock_count": outOfStockItems.length,
+    "http.duration_ms": Date.now() - pageStart,
+  });
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900">

--- a/apps/nextjs-app/src/app/recipes/actions.ts
+++ b/apps/nextjs-app/src/app/recipes/actions.ts
@@ -4,6 +4,41 @@ import { redirect } from "next/navigation";
 import { trace } from "@opentelemetry/api";
 import { graphqlRequest } from "@obs-playground/graphql-client";
 import { z } from "zod";
+import { logger } from "@/otel";
+
+type ServerAction<TArgs extends unknown[], TReturn> = (
+  ...args: TArgs
+) => Promise<TReturn>;
+
+function isRedirectError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("digest" in err)) {
+    return false;
+  }
+  const digest = err.digest;
+  return typeof digest === "string" && digest.startsWith("NEXT_REDIRECT");
+}
+
+function withActionLogging<TArgs extends unknown[], TReturn>(
+  action: ServerAction<TArgs, TReturn>,
+): ServerAction<TArgs, TReturn> {
+  return async (...args) => {
+    logger.info("Server action started", {
+      "action.function_name": action.name,
+    });
+    try {
+      return await action(...args);
+    } catch (err) {
+      if (isRedirectError(err)) {
+        throw err;
+      }
+      logger.error("Server action failed", {
+        "action.function_name": action.name,
+        err,
+      });
+      throw err;
+    }
+  };
+}
 
 function getFormString(formData: FormData, key: string): string {
   const value = formData.get(key);
@@ -17,7 +52,7 @@ const ingredientSchema = z.array(
   }),
 );
 
-export async function createRecipeAction(formData: FormData) {
+async function createRecipe(formData: FormData) {
   const activeSpan = trace.getActiveSpan();
 
   const title = getFormString(formData, "title");
@@ -75,10 +110,19 @@ export async function createRecipeAction(formData: FormData) {
     "recipe.id": createdRecipe.id,
   });
 
+  logger.info("Recipe creation submitted via server action", {
+    "recipe.id": createdRecipe.id,
+    "recipe.title": createdRecipe.title,
+    "recipe.difficulty": difficulty,
+    "recipe.servings": servings,
+    "recipe.ingredient_count": ingredients.length,
+    "recipe.ingredients_parse_success": ingredientsResult.success,
+  });
+
   redirect(`/recipes/${createdRecipe.id}`);
 }
 
-export async function updateRecipeAction(id: string, formData: FormData) {
+async function updateRecipe(id: string, formData: FormData) {
   const activeSpan = trace.getActiveSpan();
 
   activeSpan?.setAttributes({
@@ -126,10 +170,17 @@ export async function updateRecipeAction(id: string, formData: FormData) {
     },
   );
 
+  logger.info("Recipe update submitted via server action", {
+    "recipe.id": id,
+    "recipe.title": title,
+    "recipe.difficulty": difficulty,
+    "recipe.servings": servings,
+  });
+
   redirect(`/recipes/${id}`);
 }
 
-export async function deleteRecipeAction(id: string) {
+async function deleteRecipe(id: string) {
   const activeSpan = trace.getActiveSpan();
 
   activeSpan?.setAttributes({
@@ -153,6 +204,11 @@ export async function deleteRecipeAction(id: string) {
     "recipe.deletion_success": success,
   });
 
+  logger.info("Recipe deletion submitted via server action", {
+    "recipe.id": id,
+    "recipe.deletion_success": success,
+  });
+
   if (!success) {
     throw new Error("Failed to delete recipe");
   }
@@ -160,7 +216,7 @@ export async function deleteRecipeAction(id: string) {
   redirect("/");
 }
 
-export async function brokenCreateRecipeAction(_formData: FormData) {
+async function brokenCreateRecipe(_formData: FormData) {
   await graphqlRequest<{ errorMutation: string }>(
     `
       mutation ErrorMutation {
@@ -169,3 +225,8 @@ export async function brokenCreateRecipeAction(_formData: FormData) {
     `,
   );
 }
+
+export const createRecipeAction = withActionLogging(createRecipe);
+export const updateRecipeAction = withActionLogging(updateRecipe);
+export const deleteRecipeAction = withActionLogging(deleteRecipe);
+export const brokenCreateRecipeAction = withActionLogging(brokenCreateRecipe);

--- a/apps/nextjs-app/src/app/recipes/new/page.tsx
+++ b/apps/nextjs-app/src/app/recipes/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { graphqlRequest } from "@obs-playground/graphql-client";
 import { createRecipeAction } from "../actions";
+import { LoggedForm } from "@/components/logged-form";
 
 type Category = {
   id: string;
@@ -56,7 +57,15 @@ export default async function NewRecipePage() {
             </p>
           </header>
 
-          <form action={createRecipeAction} className="space-y-6">
+          <LoggedForm
+            action={createRecipeAction}
+            logMessage="Create recipe form submitted"
+            logAttributes={{
+              "form.category_count": categories.length,
+              "form.ingredient_count": ingredients.length,
+            }}
+            className="space-y-6"
+          >
             <div>
               <label
                 htmlFor="title"
@@ -240,7 +249,7 @@ export default async function NewRecipePage() {
                 Cancel
               </Link>
             </div>
-          </form>
+          </LoggedForm>
 
           <div className="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950">
             <h3 className="text-sm font-medium text-blue-900 dark:text-blue-100">

--- a/apps/nextjs-app/src/app/shopping-list/page.tsx
+++ b/apps/nextjs-app/src/app/shopping-list/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { trace } from "@opentelemetry/api";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
+import { logger } from "@/otel";
 
 const shoppingListItemSchema = z.object({
   ingredientId: z.string(),
@@ -31,6 +32,7 @@ async function generateShoppingList(
   isDefault: boolean,
 ): Promise<ShoppingListResponse> {
   const activeSpan = trace.getActiveSpan();
+  const fetchStart = Date.now();
 
   activeSpan?.setAttributes({
     "shopping_list.recipe_ids": recipeIds.join(","),
@@ -67,6 +69,17 @@ async function generateShoppingList(
     "shopping_list.out_of_stock_count": result.data.outOfStock.length,
     "shopping_list.out_of_stock_names": result.data.outOfStock,
     "shopping_list.has_out_of_stock": result.data.outOfStock.length > 0,
+  });
+
+  logger.info("Shopping list page fetched", {
+    "shopping_list.recipe_ids": recipeIds,
+    "shopping_list.recipe_count": recipeIds.length,
+    "shopping_list.using_default_ids": isDefault,
+    "shopping_list.total_items": result.data.items.length,
+    "shopping_list.total_cost": result.data.totalCost,
+    "shopping_list.out_of_stock_count": result.data.outOfStock.length,
+    "http.status_code": response.status,
+    "http.duration_ms": Date.now() - fetchStart,
   });
 
   return result.data;

--- a/apps/nextjs-app/src/app/testing/client/broken-api/page.tsx
+++ b/apps/nextjs-app/src/app/testing/client/broken-api/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { z } from "zod";
+import { datadogLogs } from "@datadog/browser-logs";
 
 const apiResponseSchema = z.record(z.string(), z.unknown());
 
@@ -18,10 +19,18 @@ export default function BrokenAPIPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
+    const url = "/api/error/test";
     try {
-      const res = await fetch("/api/error/test");
+      const res = await fetch(url);
 
       if (!res.ok) {
+        datadogLogs.logger.warn("Client API fetch returned error status", {
+          "http.url": url,
+          "http.status_code": res.status,
+          "http.status_text": res.statusText,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       }
 
@@ -31,6 +40,11 @@ export default function BrokenAPIPage() {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client API fetch failed", {
+        "http.url": url,
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -42,8 +56,10 @@ export default function BrokenAPIPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
+    const url = "/api/error/not-found";
     try {
-      const res = await fetch("/api/error/not-found");
+      const res = await fetch(url);
       const json: unknown = await res.json();
       const result = apiResponseSchema.safeParse(json);
       const data = result.success ? result.data : {};
@@ -53,11 +69,22 @@ export default function BrokenAPIPage() {
           : res.statusText;
 
       if (!res.ok) {
+        datadogLogs.logger.warn("Client API fetch returned error status", {
+          "http.url": url,
+          "http.status_code": res.status,
+          "http.status_text": res.statusText,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(`HTTP ${res.status}: ${message}`);
       } else {
         setResponse(data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client API fetch failed", {
+        "http.url": url,
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -69,8 +96,10 @@ export default function BrokenAPIPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
+    const url = "/api/error/validation";
     try {
-      const res = await fetch("/api/error/validation");
+      const res = await fetch(url);
       const json: unknown = await res.json();
       const result = apiResponseSchema.safeParse(json);
       const data = result.success ? result.data : {};
@@ -80,12 +109,23 @@ export default function BrokenAPIPage() {
           : res.statusText;
 
       if (!res.ok) {
+        datadogLogs.logger.warn("Client API fetch returned error status", {
+          "http.url": url,
+          "http.status_code": res.status,
+          "http.status_text": res.statusText,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(`HTTP ${res.status}: ${message}`);
         setResponse(data);
       } else {
         setResponse(data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client API fetch failed", {
+        "http.url": url,
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);

--- a/apps/nextjs-app/src/app/testing/client/broken-mutation/page.tsx
+++ b/apps/nextjs-app/src/app/testing/client/broken-mutation/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { graphqlRequest } from "@obs-playground/graphql-client/browser";
+import { datadogLogs } from "@datadog/browser-logs";
 
 export default function BrokenMutationPage() {
   const [loading, setLoading] = useState(false);
@@ -16,6 +17,7 @@ export default function BrokenMutationPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
     try {
       const result = await graphqlRequest<{ errorMutation: string }>(
         `
@@ -25,12 +27,25 @@ export default function BrokenMutationPage() {
         `,
       );
       if (result.errors && result.errors.length > 0) {
+        datadogLogs.logger.warn("Client GraphQL returned errors", {
+          "graphql.operation_name": "ErrorMutation",
+          "graphql.operation_type": "mutation",
+          "graphql.error_count": result.errors.length,
+          "graphql.errors": result.errors,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(JSON.stringify(result.errors));
       }
       if (result.data) {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client GraphQL request failed", {
+        "graphql.operation_name": "ErrorMutation",
+        "graphql.operation_type": "mutation",
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -42,6 +57,7 @@ export default function BrokenMutationPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
     try {
       const result = await graphqlRequest<{
         validationErrorMutation: { id: string; title: string };
@@ -67,12 +83,25 @@ export default function BrokenMutationPage() {
         `,
       );
       if (result.errors && result.errors.length > 0) {
+        datadogLogs.logger.warn("Client GraphQL returned errors", {
+          "graphql.operation_name": "ValidationError",
+          "graphql.operation_type": "mutation",
+          "graphql.error_count": result.errors.length,
+          "graphql.errors": result.errors,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(JSON.stringify(result.errors));
       }
       if (result.data) {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client GraphQL request failed", {
+        "graphql.operation_name": "ValidationError",
+        "graphql.operation_type": "mutation",
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -84,6 +113,7 @@ export default function BrokenMutationPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
     try {
       const result = await graphqlRequest<{ errorQuery: string }>(
         `
@@ -93,12 +123,25 @@ export default function BrokenMutationPage() {
         `,
       );
       if (result.errors && result.errors.length > 0) {
+        datadogLogs.logger.warn("Client GraphQL returned errors", {
+          "graphql.operation_name": "ErrorQuery",
+          "graphql.operation_type": "query",
+          "graphql.error_count": result.errors.length,
+          "graphql.errors": result.errors,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(JSON.stringify(result.errors));
       }
       if (result.data) {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client GraphQL request failed", {
+        "graphql.operation_name": "ErrorQuery",
+        "graphql.operation_type": "query",
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -110,6 +153,7 @@ export default function BrokenMutationPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
     try {
       const result = await graphqlRequest<{
         recipes: { id: string; title: string }[];
@@ -127,12 +171,25 @@ export default function BrokenMutationPage() {
         },
       );
       if (result.errors && result.errors.length > 0) {
+        datadogLogs.logger.warn("Client GraphQL returned errors", {
+          "graphql.operation_name": "RecipeQuery",
+          "graphql.operation_type": "query",
+          "graphql.error_count": result.errors.length,
+          "graphql.errors": result.errors,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(JSON.stringify(result.errors));
       }
       if (result.data) {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client GraphQL request failed", {
+        "graphql.operation_name": "RecipeQuery",
+        "graphql.operation_type": "query",
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
@@ -144,6 +201,7 @@ export default function BrokenMutationPage() {
     setError(null);
     setResponse(null);
 
+    const fetchStart = Date.now();
     try {
       const result = await graphqlRequest<{
         recipes: { id: string; title: string }[];
@@ -162,12 +220,25 @@ export default function BrokenMutationPage() {
         `,
       );
       if (result.errors && result.errors.length > 0) {
+        datadogLogs.logger.warn("Client GraphQL returned errors", {
+          "graphql.operation_name": "MultipleErrorsQuery",
+          "graphql.operation_type": "query",
+          "graphql.error_count": result.errors.length,
+          "graphql.errors": result.errors,
+          "http.duration_ms": Date.now() - fetchStart,
+        });
         setError(JSON.stringify(result.errors));
       }
       if (result.data) {
         setResponse(result.data);
       }
     } catch (err) {
+      datadogLogs.logger.error("Client GraphQL request failed", {
+        "graphql.operation_name": "MultipleErrorsQuery",
+        "graphql.operation_type": "query",
+        err,
+        "http.duration_ms": Date.now() - fetchStart,
+      });
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);

--- a/apps/nextjs-app/src/app/testing/forms/broken-create/page.tsx
+++ b/apps/nextjs-app/src/app/testing/forms/broken-create/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { brokenCreateRecipeAction } from "@/app/recipes/actions";
+import { LoggedForm } from "@/components/logged-form";
 
 export default function BrokenCreatePage() {
   return (
@@ -29,7 +30,14 @@ export default function BrokenCreatePage() {
             </p>
           </header>
 
-          <form action={brokenCreateRecipeAction} className="space-y-6">
+          <LoggedForm
+            action={brokenCreateRecipeAction}
+            logMessage="Broken-create form submitted"
+            logAttributes={{
+              "form.intentional_failure": true,
+            }}
+            className="space-y-6"
+          >
             <div>
               <label
                 htmlFor="title"
@@ -78,7 +86,7 @@ export default function BrokenCreatePage() {
                 Cancel
               </Link>
             </div>
-          </form>
+          </LoggedForm>
 
           <div className="mt-8 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-950">
             <h3 className="text-sm font-medium text-red-900 dark:text-red-100">

--- a/apps/nextjs-app/src/components/logged-form.tsx
+++ b/apps/nextjs-app/src/components/logged-form.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { datadogLogs } from "@datadog/browser-logs";
+import type { ReactNode } from "react";
+
+type LoggedFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  logMessage: string;
+  logAttributes?: Record<string, unknown>;
+  className?: string;
+  children: ReactNode;
+};
+
+export function LoggedForm({
+  action,
+  logMessage,
+  logAttributes,
+  className,
+  children,
+}: LoggedFormProps) {
+  const handleSubmit = () => {
+    datadogLogs.logger.info(logMessage, logAttributes ?? {});
+  };
+
+  return (
+    <form action={action} onSubmit={handleSubmit} className={className}>
+      {children}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- extend Express request logging and the `shopping-list`, `meal-plan`, and `batch-nutrition` routes with attribute-prefixed log fields (`http.*`, `shopping_list.*`, `meal_plan.*`, `batch_nutrition.*`) and per-stage duration tracking, including warnings for missing recipes and out-of-stock items
- enrich the GraphQL server's Apollo logging plugin, HTTP middleware, and `recipeWithCost` / `recipeWithNutrition` resolvers with operation metadata, Express call durations, and lifecycle logs; log recipe create/update/delete mutations with changed-field diffs
- add server-side logging to the Next.js `batch-nutrition`, `meal-planner`, `shopping-list`, and full-recipe pages, and wrap recipe server actions with a shared logging helper that records invocation, success, and errors while preserving `redirect` behavior
- introduce a `LoggedForm` client component and Datadog browser-logs instrumentation across the `testing/client` and form pages to capture form submissions, fetch failures, and GraphQL error responses from the browser

## Testing
- Not run (not requested)