### PR TITLE
Fix RUM tracing for service subdomains

### DIFF
--- a/apps/nextjs-app/server.ts
+++ b/apps/nextjs-app/server.ts
@@ -1,4 +1,5 @@
-import { logger } from "./src/otel";
+import "./src/otel";
+import { logger } from "./src/logger";
 import express from "express";
 import next from "next";
 import { fileURLToPath } from "node:url";

--- a/apps/nextjs-app/src/app/batch-nutrition/page.tsx
+++ b/apps/nextjs-app/src/app/batch-nutrition/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
-import { logger } from "@/otel";
+import { logger } from "@/logger";
 
 const recipeNutritionSchema = z.object({
   recipeId: z.string(),

--- a/apps/nextjs-app/src/app/meal-planner/page.tsx
+++ b/apps/nextjs-app/src/app/meal-planner/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
-import { logger } from "@/otel";
+import { logger } from "@/logger";
 
 const recipeCostSchema = z.object({
   recipeId: z.string(),

--- a/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
+++ b/apps/nextjs-app/src/app/recipes/[id]/full/page.tsx
@@ -3,7 +3,7 @@ import { graphqlRequest } from "@obs-playground/graphql-client";
 import { RecipeDetailDocument } from "@obs-playground/graphql-client/documents";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
-import { logger } from "@/otel";
+import { logger } from "@/logger";
 
 const pricesSchema = z.record(z.string(), z.number());
 

--- a/apps/nextjs-app/src/app/recipes/actions.ts
+++ b/apps/nextjs-app/src/app/recipes/actions.ts
@@ -14,7 +14,7 @@ import {
   UpdateRecipeDocument,
 } from "@obs-playground/graphql-client/documents";
 import { z } from "zod";
-import { logger } from "@/otel";
+import { logger } from "@/logger";
 
 type ServerAction<TArgs extends unknown[], TReturn> = (
   ...args: TArgs

--- a/apps/nextjs-app/src/app/shopping-list/page.tsx
+++ b/apps/nextjs-app/src/app/shopping-list/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { trace } from "@opentelemetry/api";
 import { getExpressUrl } from "@obs-playground/env";
 import { z } from "zod";
-import { logger } from "@/otel";
+import { logger } from "@/logger";
 
 const shoppingListItemSchema = z.object({
   ingredientId: z.string(),

--- a/apps/nextjs-app/src/instrumentation-client.ts
+++ b/apps/nextjs-app/src/instrumentation-client.ts
@@ -2,6 +2,17 @@ import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
 import { reactPlugin } from "@datadog/browser-rum-react";
 
+function getRootDomain(hostname: string) {
+  const parts = hostname.split(".");
+  if (parts.length <= 2) return hostname;
+  return parts.slice(-2).join(".");
+}
+
+function matchesTraceDomain(hostname: string) {
+  const rootDomain = getRootDomain(window.location.hostname);
+  return hostname === rootDomain || hostname.endsWith(`.${rootDomain}`);
+}
+
 datadogLogs.init({
   clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN ?? "",
   site: "datadoghq.com",
@@ -33,7 +44,7 @@ datadogRum.init({
         if (parsedUrl.pathname.startsWith("/_")) {
           return false;
         }
-        if (parsedUrl.hostname !== window.location.hostname) {
+        if (!matchesTraceDomain(parsedUrl.hostname)) {
           return false;
         }
         return true;

--- a/apps/nextjs-app/src/logger.ts
+++ b/apps/nextjs-app/src/logger.ts
@@ -1,0 +1,5 @@
+import { createLogger } from "@obs-playground/otel";
+
+export const logger = createLogger(
+  process.env.CUSTOM_SERVER ? "nextjs-custom-server" : "nextjs-app",
+);

--- a/apps/nextjs-app/src/otel.ts
+++ b/apps/nextjs-app/src/otel.ts
@@ -2,7 +2,7 @@ import { initializeOtel } from "@obs-playground/otel";
 
 process.env.NEXT_OTEL_FETCH_DISABLED = "1";
 
-export const { logger } = initializeOtel({
+initializeOtel({
   serviceName: process.env.CUSTOM_SERVER
     ? "nextjs-custom-server"
     : "nextjs-app",

--- a/apps/tanstack-start/src/client.tsx
+++ b/apps/tanstack-start/src/client.tsx
@@ -4,6 +4,17 @@ import { StartClient } from "@tanstack/react-start/client";
 import { StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
+function getRootDomain(hostname: string) {
+  const parts = hostname.split(".");
+  if (parts.length <= 2) return hostname;
+  return parts.slice(-2).join(".");
+}
+
+function matchesTraceDomain(hostname: string) {
+  const rootDomain = getRootDomain(window.location.hostname);
+  return hostname === rootDomain || hostname.endsWith(`.${rootDomain}`);
+}
+
 datadogLogs.init({
   clientToken: String(import.meta.env.VITE_DATADOG_CLIENT_TOKEN ?? ""),
   site: "datadoghq.com",
@@ -28,7 +39,16 @@ datadogRum.init({
   trackUserInteractions: true,
   allowedTracingUrls: [
     {
-      match: () => true,
+      match: (url: string) => {
+        const parsedUrl = new URL(url);
+        if (parsedUrl.pathname.startsWith("/_")) {
+          return false;
+        }
+        if (!matchesTraceDomain(parsedUrl.hostname)) {
+          return false;
+        }
+        return true;
+      },
       propagatorTypes: ["tracecontext", "datadog"],
     },
   ],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:dd": "bash scripts/dev.sh dd",
     "start": "bash scripts/start.sh",
     "build": "turbo run build && npm run build:custom -w nextjs-app",
+    "build:packages": "turbo run build --filter='./packages/*'",
     "type-check": "turbo run type-check",
     "lint": "turbo run lint && npm run graphql:lint",
     "graphql:codegen": "graphql-codegen --config codegen.mjs",


### PR DESCRIPTION
## Summary
- Allow RUM trace propagation across the current root domain and its service subdomains.
- Keep framework-internal `/_*` requests excluded from tracing.
- Align TanStack RUM tracing with the same domain/subdomain allowlist instead of tracing every URL.