### PR TITLE
Build distinct Next.js containers

### DIFF
--- a/.github/workflows/nextjs-containers.yml
+++ b/.github/workflows/nextjs-containers.yml
@@ -43,7 +43,7 @@ jobs:
   smoke-test:
     name: Build and smoke test
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nextjs-containers.yml
+++ b/.github/workflows/nextjs-containers.yml
@@ -1,0 +1,53 @@
+name: Next.js Containers
+
+on:
+  pull_request:
+    branches: [main, create-hemlchart]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/nextjs-containers.yml"
+      - "apps/nextjs-app/**"
+      - "deploy/docker/nextjs/**"
+      - "deploy/docker/nextjs-custom/**"
+      - "packages/env/**"
+      - "packages/graphql-client/**"
+      - "packages/otel/**"
+      - "packages/trpc-otel/**"
+      - "patches/**"
+      - "scripts/smoke-nextjs-containers.sh"
+      - "package.json"
+      - "package-lock.json"
+      - "turbo.json"
+  push:
+    branches: [main]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/nextjs-containers.yml"
+      - "apps/nextjs-app/**"
+      - "deploy/docker/nextjs/**"
+      - "deploy/docker/nextjs-custom/**"
+      - "packages/env/**"
+      - "packages/graphql-client/**"
+      - "packages/otel/**"
+      - "packages/trpc-otel/**"
+      - "patches/**"
+      - "scripts/smoke-nextjs-containers.sh"
+      - "package.json"
+      - "package-lock.json"
+      - "turbo.json"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Build and smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build and smoke test Next.js images
+        run: scripts/smoke-nextjs-containers.sh

--- a/apps/nextjs-app/next.config.ts
+++ b/apps/nextjs-app/next.config.ts
@@ -16,6 +16,7 @@ const allowedDevOrigins = [
 
 const nextConfig = {
   distDir: process.env.CUSTOM_SERVER === "true" ? ".next-custom" : ".next",
+  output: "standalone",
   allowedDevOrigins,
   serverExternalPackages: [
     "@opentelemetry/api",

--- a/apps/nextjs-app/next.config.ts
+++ b/apps/nextjs-app/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { fileURLToPath } from "node:url";
 
 function hostnameFromUrl(url: string | undefined): string | null {
   if (!url) return null;
@@ -17,6 +18,7 @@ const allowedDevOrigins = [
 const nextConfig = {
   distDir: process.env.CUSTOM_SERVER === "true" ? ".next-custom" : ".next",
   output: "standalone",
+  outputFileTracingRoot: fileURLToPath(new URL("../..", import.meta.url)),
   allowedDevOrigins,
   serverExternalPackages: [
     "@opentelemetry/api",

--- a/apps/nextjs-app/server.ts
+++ b/apps/nextjs-app/server.ts
@@ -17,6 +17,10 @@ const handle = app.getRequestHandler();
 const server = express();
 
 app.prepare().then(() => {
+  server.get("/health", (_req, res) => {
+    res.json({ status: "healthy" });
+  });
+
   server.use((req, res) => {
     return handle(req, res);
   });

--- a/apps/nextjs-app/server.ts
+++ b/apps/nextjs-app/server.ts
@@ -17,6 +17,7 @@ const handle = app.getRequestHandler();
 const server = express();
 
 app.prepare().then(() => {
+  // Bypass the Next.js request pipeline for lightweight Kubernetes probes.
   server.get("/health", (_req, res) => {
     res.json({ status: "healthy" });
   });

--- a/apps/nextjs-app/src/app/health/route.ts
+++ b/apps/nextjs-app/src/app/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: "healthy" });
+}

--- a/deploy/docker/nextjs-custom/Dockerfile
+++ b/deploy/docker/nextjs-custom/Dockerfile
@@ -46,27 +46,29 @@ ENV CUSTOM_SERVER=true \
 
 WORKDIR /app
 
-COPY --from=builder /app/apps/nextjs-app/.next-custom/standalone ./
-COPY --from=builder /app/apps/nextjs-app/.next-custom/static ./apps/nextjs-app/.next-custom/static
-COPY --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
-COPY --from=builder /app/apps/nextjs-app/next.config.ts ./apps/nextjs-app/next.config.ts
-COPY --from=builder /app/apps/nextjs-app/server.ts ./apps/nextjs-app/server.ts
-COPY --from=builder /app/apps/nextjs-app/src/otel.ts ./apps/nextjs-app/src/otel.ts
-COPY --from=builder /app/apps/nextjs-app/src/logger.ts ./apps/nextjs-app/src/logger.ts
-COPY --from=production-dependencies /app/node_modules ./node_modules
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/.next-custom/standalone ./
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/.next-custom/static ./apps/nextjs-app/.next-custom/static
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/next.config.ts ./apps/nextjs-app/next.config.ts
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/server.ts ./apps/nextjs-app/server.ts
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/src/otel.ts ./apps/nextjs-app/src/otel.ts
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/src/logger.ts ./apps/nextjs-app/src/logger.ts
+COPY --chown=node:node --from=production-dependencies /app/node_modules ./node_modules
 # The production install skips postinstall; keep these copies in sync with runtime dependencies in patches/.
-COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-graphql ./node_modules/@opentelemetry/instrumentation-graphql
-COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-http ./node_modules/@opentelemetry/instrumentation-http
-COPY --from=builder /app/packages/env/package.json ./packages/env/package.json
-COPY --from=builder /app/packages/env/dist ./packages/env/dist
-COPY --from=builder /app/packages/graphql-client/package.json ./packages/graphql-client/package.json
-COPY --from=builder /app/packages/graphql-client/dist ./packages/graphql-client/dist
-COPY --from=builder /app/packages/otel/package.json ./packages/otel/package.json
-COPY --from=builder /app/packages/otel/dist ./packages/otel/dist
-COPY --from=builder /app/packages/trpc-otel/package.json ./packages/trpc-otel/package.json
-COPY --from=builder /app/packages/trpc-otel/dist ./packages/trpc-otel/dist
+COPY --chown=node:node --from=builder /app/node_modules/@opentelemetry/instrumentation-graphql ./node_modules/@opentelemetry/instrumentation-graphql
+COPY --chown=node:node --from=builder /app/node_modules/@opentelemetry/instrumentation-http ./node_modules/@opentelemetry/instrumentation-http
+COPY --chown=node:node --from=builder /app/packages/env/package.json ./packages/env/package.json
+COPY --chown=node:node --from=builder /app/packages/env/dist ./packages/env/dist
+COPY --chown=node:node --from=builder /app/packages/graphql-client/package.json ./packages/graphql-client/package.json
+COPY --chown=node:node --from=builder /app/packages/graphql-client/dist ./packages/graphql-client/dist
+COPY --chown=node:node --from=builder /app/packages/otel/package.json ./packages/otel/package.json
+COPY --chown=node:node --from=builder /app/packages/otel/dist ./packages/otel/dist
+COPY --chown=node:node --from=builder /app/packages/trpc-otel/package.json ./packages/trpc-otel/package.json
+COPY --chown=node:node --from=builder /app/packages/trpc-otel/dist ./packages/trpc-otel/dist
 
 WORKDIR /app/apps/nextjs-app
+
+USER node
 
 EXPOSE 3000
 

--- a/deploy/docker/nextjs-custom/Dockerfile
+++ b/deploy/docker/nextjs-custom/Dockerfile
@@ -63,6 +63,7 @@ COPY --chown=node:node --from=builder /app/packages/graphql-client/package.json 
 COPY --chown=node:node --from=builder /app/packages/graphql-client/dist ./packages/graphql-client/dist
 COPY --chown=node:node --from=builder /app/packages/otel/package.json ./packages/otel/package.json
 COPY --chown=node:node --from=builder /app/packages/otel/dist ./packages/otel/dist
+COPY --chown=node:node --from=production-dependencies /app/packages/otel/node_modules ./packages/otel/node_modules
 COPY --chown=node:node --from=builder /app/packages/trpc-otel/package.json ./packages/trpc-otel/package.json
 COPY --chown=node:node --from=builder /app/packages/trpc-otel/dist ./packages/trpc-otel/dist
 

--- a/deploy/docker/nextjs-custom/Dockerfile
+++ b/deploy/docker/nextjs-custom/Dockerfile
@@ -1,0 +1,72 @@
+FROM node:24-bookworm-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps ./apps
+COPY packages ./packages
+
+RUN npm ci
+
+ARG DATADOG_APP_ID
+ARG DATADOG_CLIENT_TOKEN
+ARG NEXT_PUBLIC_GRAPHQL_BASE_URL
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_STATSIG_CLIENT_KEY
+
+ENV CUSTOM_SERVER=true \
+    NEXT_PUBLIC_DATADOG_APP_ID=$DATADOG_APP_ID \
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=$DATADOG_CLIENT_TOKEN \
+    NEXT_PUBLIC_GRAPHQL_BASE_URL=$NEXT_PUBLIC_GRAPHQL_BASE_URL \
+    NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN \
+    NEXT_PUBLIC_STATSIG_CLIENT_KEY=$NEXT_PUBLIC_STATSIG_CLIENT_KEY
+
+RUN npm run build:packages && npm run build:custom --workspace nextjs-app
+
+FROM node:24-bookworm-slim AS production-dependencies
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/nextjs-app/package.json ./apps/nextjs-app/package.json
+COPY packages/env/package.json ./packages/env/package.json
+COPY packages/graphql-client/package.json ./packages/graphql-client/package.json
+COPY packages/otel/package.json ./packages/otel/package.json
+COPY packages/trpc-otel/package.json ./packages/trpc-otel/package.json
+
+RUN npm ci --omit=dev --ignore-scripts \
+    --workspace=nextjs-app --include-workspace-root=false
+
+FROM node:24-bookworm-slim AS runtime
+
+ENV CUSTOM_SERVER=true \
+    NODE_ENV=production \
+    PORT=3000
+
+WORKDIR /app
+
+COPY --from=builder /app/apps/nextjs-app/.next-custom/standalone ./
+COPY --from=builder /app/apps/nextjs-app/.next-custom/static ./apps/nextjs-app/.next-custom/static
+COPY --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
+COPY --from=builder /app/apps/nextjs-app/next.config.ts ./apps/nextjs-app/next.config.ts
+COPY --from=builder /app/apps/nextjs-app/server.ts ./apps/nextjs-app/server.ts
+COPY --from=builder /app/apps/nextjs-app/src/otel.ts ./apps/nextjs-app/src/otel.ts
+COPY --from=builder /app/apps/nextjs-app/src/logger.ts ./apps/nextjs-app/src/logger.ts
+COPY --from=production-dependencies /app/node_modules ./node_modules
+COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-graphql ./node_modules/@opentelemetry/instrumentation-graphql
+COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-http ./node_modules/@opentelemetry/instrumentation-http
+COPY --from=builder /app/packages/env/package.json ./packages/env/package.json
+COPY --from=builder /app/packages/env/dist ./packages/env/dist
+COPY --from=builder /app/packages/graphql-client/package.json ./packages/graphql-client/package.json
+COPY --from=builder /app/packages/graphql-client/dist ./packages/graphql-client/dist
+COPY --from=builder /app/packages/otel/package.json ./packages/otel/package.json
+COPY --from=builder /app/packages/otel/dist ./packages/otel/dist
+COPY --from=builder /app/packages/trpc-otel/package.json ./packages/trpc-otel/package.json
+COPY --from=builder /app/packages/trpc-otel/dist ./packages/trpc-otel/dist
+
+WORKDIR /app/apps/nextjs-app
+
+EXPOSE 3000
+
+CMD ["node", "--import", "tsx", "server.ts"]

--- a/deploy/docker/nextjs-custom/Dockerfile
+++ b/deploy/docker/nextjs-custom/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=builder /app/apps/nextjs-app/server.ts ./apps/nextjs-app/server.ts
 COPY --from=builder /app/apps/nextjs-app/src/otel.ts ./apps/nextjs-app/src/otel.ts
 COPY --from=builder /app/apps/nextjs-app/src/logger.ts ./apps/nextjs-app/src/logger.ts
 COPY --from=production-dependencies /app/node_modules ./node_modules
-# The production install skips postinstall, so restore dependencies patched in the builder.
+# The production install skips postinstall; keep these copies in sync with runtime dependencies in patches/.
 COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-graphql ./node_modules/@opentelemetry/instrumentation-graphql
 COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-http ./node_modules/@opentelemetry/instrumentation-http
 COPY --from=builder /app/packages/env/package.json ./packages/env/package.json

--- a/deploy/docker/nextjs-custom/Dockerfile
+++ b/deploy/docker/nextjs-custom/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=builder /app/apps/nextjs-app/server.ts ./apps/nextjs-app/server.ts
 COPY --from=builder /app/apps/nextjs-app/src/otel.ts ./apps/nextjs-app/src/otel.ts
 COPY --from=builder /app/apps/nextjs-app/src/logger.ts ./apps/nextjs-app/src/logger.ts
 COPY --from=production-dependencies /app/node_modules ./node_modules
+# The production install skips postinstall, so restore dependencies patched in the builder.
 COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-graphql ./node_modules/@opentelemetry/instrumentation-graphql
 COPY --from=builder /app/node_modules/@opentelemetry/instrumentation-http ./node_modules/@opentelemetry/instrumentation-http
 COPY --from=builder /app/packages/env/package.json ./packages/env/package.json

--- a/deploy/docker/nextjs/Dockerfile
+++ b/deploy/docker/nextjs/Dockerfile
@@ -31,11 +31,13 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-COPY --from=builder /app/apps/nextjs-app/.next/standalone ./
-COPY --from=builder /app/apps/nextjs-app/.next/static ./apps/nextjs-app/.next/static
-COPY --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/.next/standalone ./
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/.next/static ./apps/nextjs-app/.next/static
+COPY --chown=node:node --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
 
 WORKDIR /app/apps/nextjs-app
+
+USER node
 
 EXPOSE 3000
 

--- a/deploy/docker/nextjs/Dockerfile
+++ b/deploy/docker/nextjs/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:24-bookworm-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json turbo.json ./
+COPY patches ./patches
+COPY apps ./apps
+COPY packages ./packages
+
+RUN npm ci
+
+ARG DATADOG_APP_ID
+ARG DATADOG_CLIENT_TOKEN
+ARG NEXT_PUBLIC_GRAPHQL_BASE_URL
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_STATSIG_CLIENT_KEY
+
+ENV NEXT_PUBLIC_DATADOG_APP_ID=$DATADOG_APP_ID \
+    NEXT_PUBLIC_DATADOG_CLIENT_TOKEN=$DATADOG_CLIENT_TOKEN \
+    NEXT_PUBLIC_GRAPHQL_BASE_URL=$NEXT_PUBLIC_GRAPHQL_BASE_URL \
+    NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN \
+    NEXT_PUBLIC_STATSIG_CLIENT_KEY=$NEXT_PUBLIC_STATSIG_CLIENT_KEY
+
+RUN npm run build:packages && npm run build --workspace nextjs-app
+
+FROM node:24-bookworm-slim AS runtime
+
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+WORKDIR /app
+
+COPY --from=builder /app/apps/nextjs-app/.next/standalone ./
+COPY --from=builder /app/apps/nextjs-app/.next/static ./apps/nextjs-app/.next/static
+COPY --from=builder /app/apps/nextjs-app/public ./apps/nextjs-app/public
+
+WORKDIR /app/apps/nextjs-app
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "playwright:slow": "eval \"$(node scripts/portless-env.mjs shell)\" && BASE_URL=${BASE_URL} SLOW_TESTS=true npm run test -w @obs-playground/playwright-tests",
     "playwright:repeat": "npm run test:repeat -w @obs-playground/playwright-tests",
     "smoke:express-container": "bash deploy/docker/express/smoke-test.sh",
+    "smoke:nextjs-containers": "bash scripts/smoke-nextjs-containers.sh",
     "smoke:tanstack-container": "bash deploy/docker/tanstack/smoke-test.sh"
   },
   "keywords": [],

--- a/scripts/smoke-nextjs-containers.sh
+++ b/scripts/smoke-nextjs-containers.sh
@@ -41,6 +41,11 @@ docker run --rm "$standard_image" sh -c \
 docker run --rm "$custom_image" sh -c \
   'test -f .next-custom/BUILD_ID && test ! -e .next && test -f server.ts && node --import tsx --eval ""'
 
+for image in "$standard_image" "$custom_image"; do
+  docker run --rm "$image" sh -c \
+    'grep --quiet "Only set status if it.*ERROR" /app/node_modules/@opentelemetry/instrumentation-http/build/src/http.js && grep --quiet OPERATION_SPAN_KEY /app/node_modules/@opentelemetry/instrumentation-graphql/build/src/instrumentation.js'
+done
+
 docker run --detach --name "$standard_container" --publish 3100:3000 \
   "$standard_image" >/dev/null
 docker run --detach --name "$custom_container" --publish 3101:3000 \

--- a/scripts/smoke-nextjs-containers.sh
+++ b/scripts/smoke-nextjs-containers.sh
@@ -35,6 +35,8 @@ test "$(docker image inspect --format '{{json .Config.Cmd}}' "$standard_image")"
   '["node","server.js"]'
 test "$(docker image inspect --format '{{json .Config.Cmd}}' "$custom_image")" = \
   '["node","--import","tsx","server.ts"]'
+test "$(docker image inspect --format '{{.Config.User}}' "$standard_image")" = "node"
+test "$(docker image inspect --format '{{.Config.User}}' "$custom_image")" = "node"
 
 docker run --rm "$standard_image" sh -c \
   'test -f .next/BUILD_ID && test ! -e .next-custom && test ! -e server.ts'

--- a/scripts/smoke-nextjs-containers.sh
+++ b/scripts/smoke-nextjs-containers.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+standard_image="obs-playground-nextjs:smoke"
+custom_image="obs-playground-nextjs-custom:smoke"
+standard_container="obs-playground-nextjs-smoke"
+custom_container="obs-playground-nextjs-custom-smoke"
+
+cleanup() {
+  docker rm -f "$standard_container" "$custom_container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_page() {
+  local url=$1
+  for _ in {1..120}; do
+    if curl --fail --silent --show-error "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for $url" >&2
+  return 1
+}
+
+docker build --platform linux/amd64 \
+  --file deploy/docker/nextjs/Dockerfile \
+  --tag "$standard_image" .
+docker build --platform linux/amd64 \
+  --file deploy/docker/nextjs-custom/Dockerfile \
+  --tag "$custom_image" .
+
+test "$(docker image inspect --format '{{json .Config.Cmd}}' "$standard_image")" = \
+  '["node","server.js"]'
+test "$(docker image inspect --format '{{json .Config.Cmd}}' "$custom_image")" = \
+  '["node","--import","tsx","server.ts"]'
+
+docker run --rm "$standard_image" sh -c \
+  'test -f .next/BUILD_ID && test ! -e .next-custom && test ! -e server.ts'
+docker run --rm "$custom_image" sh -c \
+  'test -f .next-custom/BUILD_ID && test ! -e .next && test -f server.ts && node --import tsx --eval ""'
+
+docker run --detach --name "$standard_container" --publish 3100:3000 \
+  "$standard_image" >/dev/null
+docker run --detach --name "$custom_container" --publish 3101:3000 \
+  "$custom_image" >/dev/null
+
+wait_for_page http://127.0.0.1:3100/health
+wait_for_page http://127.0.0.1:3101/health
+curl --fail --silent http://127.0.0.1:3100/health | grep --quiet '"status":"healthy"'
+curl --fail --silent http://127.0.0.1:3101/health | grep --quiet '"status":"healthy"'
+curl --fail --silent http://127.0.0.1:3100/ | grep --quiet 'Recipe &amp; Meal Planning'
+curl --fail --silent http://127.0.0.1:3101/ | grep --quiet 'Recipe &amp; Meal Planning'

--- a/scripts/smoke-nextjs-containers.sh
+++ b/scripts/smoke-nextjs-containers.sh
@@ -42,6 +42,8 @@ docker run --rm "$standard_image" sh -c \
   'test -f .next/BUILD_ID && test ! -e .next-custom && test ! -e server.ts'
 docker run --rm "$custom_image" sh -c \
   'test -f .next-custom/BUILD_ID && test ! -e .next && test -f server.ts && node --import tsx --eval ""'
+docker run --rm "$custom_image" sh -c \
+  'node --eval "const version = require(\"/app/packages/otel/node_modules/@opentelemetry/api-logs/package.json\").version; if (version !== \"0.214.0\") process.exit(1)"'
 
 for image in "$standard_image" "$custom_image"; do
   docker run --rm "$image" sh -c \


### PR DESCRIPTION
## Summary
- Add dedicated `linux/amd64` production images for the standard Next.js standalone server and the custom Express-based Next.js server, each with its own build artifact and fixed startup command.
- Bake existing browser configuration into both builds, including mapping release-time Datadog arguments to `NEXT_PUBLIC_DATADOG_*`, while limiting final images to their frontend runtime and required workspace dependencies.
- Add dependency-free health handling for both variants and a reusable container smoke test that checks artifact separation, configured commands, health, and rendered HTML.
- Keep the combined Render image and deployment configuration unchanged.

## Verification
- Both standard and custom production artifacts built successfully; direct runtime smoke checks verified health and rendered HTML for each server mode.
- The custom production dependency closure was installed independently and validated with its TypeScript runtime entrypoint and required workspace links.
- The automated image-level smoke test builds both images for `linux/amd64` and exercises the full container boundary, but could not be run locally because no Docker daemon is available; CI remains the image-level confidence boundary.

<!-- pi-orchestration-run: 8e9bfb61-0701-4c00-af07-45ca22520c6f -->
