### PR TITLE
Package OBS Playground Helm chart

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,46 @@
+name: Helm Chart
+
+on:
+  pull_request:
+    branches: [main, create-hemlchart]
+    paths:
+      - ".github/workflows/helm-chart.yml"
+      - "deploy/helm/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/helm-chart.yml"
+      - "deploy/helm/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Lint and template test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Install chart test tools
+        env:
+          KUBECONFORM_VERSION: v0.7.0
+          YQ_VERSION: v4.45.4
+        run: |
+          curl --fail --silent --show-error --location \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar --extract --gzip --directory /usr/local/bin kubeconform
+          sudo curl --fail --silent --show-error --location \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            --output /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Validate chart
+        run: deploy/helm/obs-playground/tests/template-test.sh

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 apps/*/drizzle
+# Helm Go templates are not valid standalone YAML.
+deploy/helm/*/templates/*.yaml

--- a/deploy/helm/obs-playground/Chart.yaml
+++ b/deploy/helm/obs-playground/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: obs-playground
+description: Portable deployment of the five OBS Playground services
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/deploy/helm/obs-playground/README.md
+++ b/deploy/helm/obs-playground/README.md
@@ -4,11 +4,11 @@ This chart deploys GraphQL, Express, standard Next.js, custom-server Next.js, an
 
 ## Runtime configuration
 
-The chart derives internal `GRAPHQL_BASE_URL` and `EXPRESS_BASE_URL` values from the release's Kubernetes Services. Shared runtime variables can be supplied with `global.env`, and service-specific variables with `workloads.<service>.env`; both accept Kubernetes `EnvVar` objects, including `secretKeyRef` values.
+The chart derives internal `GRAPHQL_BASE_URL` and `EXPRESS_BASE_URL` values from the release's Kubernetes Services. Set `publicBaseUrls.graphql` and `publicBaseUrls.express` to the browser-reachable ingress origins; frontends inject these public values into browser pages while retaining cluster-local URLs for server-side requests. Shared runtime variables can be supplied with `global.env`, and service-specific variables with `workloads.<service>.env`; both accept Kubernetes `EnvVar` objects, including `secretKeyRef` values.
 
 Set `datadog.otlpEndpoint` to an existing OTLP receiver to export telemetry. The default `datadog.otlpProtocol` is `grpc`; the chart does not deploy a Datadog Agent or accept Datadog credentials.
 
-Express always runs one replica with the `Recreate` strategy and mounts its PVC at `/var/data`. Set `persistence.storageClass` and `persistence.capacity`, or provide `persistence.existingClaim` to reuse a claim.
+Express always runs one replica with the `Recreate` strategy and mounts its PVC at `/var/data`. Its pod uses the image's node group (GID 1000) as `fsGroup` so dynamically provisioned volumes are writable. Set `persistence.storageClass` and `persistence.capacity`, or provide `persistence.existingClaim` to reuse a claim.
 
 Each ingress is disabled by default and can be configured independently under `workloads.<service>.ingress`. Browser-visible `NEXT_PUBLIC_*` and `VITE_*` settings are compiled into the frontend images and must be supplied when those images are built; Helm values configure the server runtimes.
 

--- a/deploy/helm/obs-playground/README.md
+++ b/deploy/helm/obs-playground/README.md
@@ -1,0 +1,22 @@
+# OBS Playground Helm chart
+
+This chart deploys GraphQL, Express, standard Next.js, custom-server Next.js, and TanStack Start. It contains no ingress hostnames, credentials, authentication middleware, or cluster-specific resources by default.
+
+## Runtime configuration
+
+The chart derives internal `GRAPHQL_BASE_URL` and `EXPRESS_BASE_URL` values from the release's Kubernetes Services. Shared runtime variables can be supplied with `global.env`, and service-specific variables with `workloads.<service>.env`; both accept Kubernetes `EnvVar` objects, including `secretKeyRef` values.
+
+Set `datadog.otlpEndpoint` to an existing OTLP receiver to export telemetry. The default `datadog.otlpProtocol` is `grpc`; the chart does not deploy a Datadog Agent or accept Datadog credentials.
+
+Express always runs one replica with the `Recreate` strategy and mounts its PVC at `/var/data`. Set `persistence.storageClass` and `persistence.capacity`, or provide `persistence.existingClaim` to reuse a claim.
+
+Each ingress is disabled by default and can be configured independently under `workloads.<service>.ingress`. Browser-visible `NEXT_PUBLIC_*` and `VITE_*` settings are compiled into the frontend images and must be supplied when those images are built; Helm values configure the server runtimes.
+
+## Validation
+
+The representative test requires Helm, kubeconform, yq v4, and Python 3.
+
+```bash
+helm lint deploy/helm/obs-playground
+deploy/helm/obs-playground/tests/template-test.sh
+```

--- a/deploy/helm/obs-playground/templates/_helpers.tpl
+++ b/deploy/helm/obs-playground/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{- define "obs-playground.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "obs-playground.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := include "obs-playground.name" . }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "obs-playground.componentName" -}}
+{{- if eq . "nextjsCustom" }}nextjs-custom{{ else }}{{ . }}{{ end }}
+{{- end }}
+
+{{- define "obs-playground.workloadName" -}}
+{{- printf "%s-%s" (include "obs-playground.fullname" .root) (include "obs-playground.componentName" .component) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "obs-playground.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "obs-playground.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "obs-playground.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "obs-playground.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ include "obs-playground.componentName" .component }}
+{{- end }}
+
+{{- define "obs-playground.expressClaimName" -}}
+{{- default (printf "%s-express-data" (include "obs-playground.fullname" .)) .Values.persistence.existingClaim }}
+{{- end }}

--- a/deploy/helm/obs-playground/templates/_helpers.tpl
+++ b/deploy/helm/obs-playground/templates/_helpers.tpl
@@ -20,7 +20,10 @@
 {{- end }}
 
 {{- define "obs-playground.workloadName" -}}
-{{- printf "%s-%s" (include "obs-playground.fullname" .root) (include "obs-playground.componentName" .component) | trunc 63 | trimSuffix "-" }}
+{{- $component := include "obs-playground.componentName" .component }}
+{{- $prefixLength := sub 62 (len $component) }}
+{{- $prefix := include "obs-playground.fullname" .root | trunc (int $prefixLength) | trimSuffix "-" }}
+{{- printf "%s-%s" $prefix $component }}
 {{- end }}
 
 {{- define "obs-playground.labels" -}}
@@ -37,5 +40,12 @@ app.kubernetes.io/component: {{ include "obs-playground.componentName" .componen
 {{- end }}
 
 {{- define "obs-playground.expressClaimName" -}}
-{{- default (printf "%s-express-data" (include "obs-playground.fullname" .)) .Values.persistence.existingClaim }}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- $suffix := "express-data" }}
+{{- $prefixLength := sub 62 (len $suffix) }}
+{{- $prefix := include "obs-playground.fullname" . | trunc (int $prefixLength) | trimSuffix "-" }}
+{{- printf "%s-%s" $prefix $suffix }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/obs-playground/templates/deployments.yaml
+++ b/deploy/helm/obs-playground/templates/deployments.yaml
@@ -1,0 +1,91 @@
+{{- $root := . -}}
+{{- range $component := list "graphql" "express" "nextjs" "nextjsCustom" "tanstack" }}
+{{- $workload := index $root.Values.workloads $component }}
+{{- $context := dict "root" $root "component" $component }}
+{{- $customEnv := dict }}
+{{- $reservedEnv := list "NODE_ENV" "PORT" "DATADOG_OTLP_PROTOCOL" "DATADOG_OTLP_ENDPOINT" "GRAPHQL_BASE_URL" "EXPRESS_BASE_URL" "SQLITE_PATH" }}
+{{- range $entry := concat $root.Values.global.env $workload.env }}
+{{- if not $entry.name }}{{ fail (printf "global.env and workloads.%s.env entries require a name" $component) }}{{ end }}
+{{- if has $entry.name $reservedEnv }}{{ fail (printf "%s is managed by the chart and cannot be set in global.env or workloads.%s.env" $entry.name $component) }}{{ end }}
+{{- $_ := set $customEnv $entry.name $entry }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obs-playground.workloadName" $context }}
+  labels:
+    {{- include "obs-playground.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ include "obs-playground.componentName" $component }}
+spec:
+  replicas: {{ if eq $component "express" }}1{{ else }}{{ $workload.replicaCount }}{{ end }}
+  strategy:
+    type: {{ if eq $component "express" }}Recreate{{ else }}RollingUpdate{{ end }}
+  selector:
+    matchLabels:
+      {{- include "obs-playground.selectorLabels" $context | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "obs-playground.selectorLabels" $context | nindent 8 }}
+    spec:
+      {{- with $root.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "obs-playground.componentName" $component }}
+          image: "{{ $workload.image.repository }}:{{ default $root.Chart.AppVersion $workload.image.tag }}"
+          imagePullPolicy: {{ $workload.image.pullPolicy }}
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: {{ $workload.containerPort | quote }}
+            - name: DATADOG_OTLP_PROTOCOL
+              value: {{ $root.Values.datadog.otlpProtocol | quote }}
+            {{- with $root.Values.datadog.otlpEndpoint }}
+            - name: DATADOG_OTLP_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or (eq $component "express") (eq $component "nextjs") (eq $component "nextjsCustom") (eq $component "tanstack") }}
+            - name: GRAPHQL_BASE_URL
+              value: "http://{{ include "obs-playground.workloadName" (dict "root" $root "component" "graphql") }}:{{ $root.Values.workloads.graphql.service.port }}"
+            {{- end }}
+            {{- if or (eq $component "graphql") (eq $component "nextjs") (eq $component "nextjsCustom") (eq $component "tanstack") }}
+            - name: EXPRESS_BASE_URL
+              value: "http://{{ include "obs-playground.workloadName" (dict "root" $root "component" "express") }}:{{ $root.Values.workloads.express.service.port }}"
+            {{- end }}
+            {{- if eq $component "express" }}
+            - name: SQLITE_PATH
+              value: /var/data/app.db
+            {{- end }}
+            {{- range $name := keys $customEnv | sortAlpha }}
+            {{- list (index $customEnv $name) | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $workload.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml $workload.resources | nindent 12 }}
+          {{- if eq $component "express" }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/data
+          {{- end }}
+      {{- if eq $component "express" }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "obs-playground.expressClaimName" $root }}
+      {{- end }}
+---
+{{- end }}

--- a/deploy/helm/obs-playground/templates/deployments.yaml
+++ b/deploy/helm/obs-playground/templates/deployments.yaml
@@ -3,7 +3,7 @@
 {{- $workload := index $root.Values.workloads $component }}
 {{- $context := dict "root" $root "component" $component }}
 {{- $customEnv := dict }}
-{{- $reservedEnv := list "NODE_ENV" "PORT" "DATADOG_OTLP_PROTOCOL" "DATADOG_OTLP_ENDPOINT" "GRAPHQL_BASE_URL" "EXPRESS_BASE_URL" "SQLITE_PATH" }}
+{{- $reservedEnv := list "NODE_ENV" "PORT" "DATADOG_OTLP_PROTOCOL" "DATADOG_OTLP_ENDPOINT" "GRAPHQL_BASE_URL" "EXPRESS_BASE_URL" "PUBLIC_GRAPHQL_BASE_URL" "PUBLIC_EXPRESS_BASE_URL" "SQLITE_PATH" }}
 {{- range $entry := concat $root.Values.global.env $workload.env }}
 {{- if not $entry.name }}{{ fail (printf "global.env and workloads.%s.env entries require a name" $component) }}{{ end }}
 {{- if has $entry.name $reservedEnv }}{{ fail (printf "%s is managed by the chart and cannot be set in global.env or workloads.%s.env" $entry.name $component) }}{{ end }}
@@ -28,6 +28,11 @@ spec:
       labels:
         {{- include "obs-playground.selectorLabels" $context | nindent 8 }}
     spec:
+      {{- if eq $component "express" }}
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      {{- end }}
       {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -54,6 +59,16 @@ spec:
             {{- if or (eq $component "graphql") (eq $component "nextjs") (eq $component "nextjsCustom") (eq $component "tanstack") }}
             - name: EXPRESS_BASE_URL
               value: "http://{{ include "obs-playground.workloadName" (dict "root" $root "component" "express") }}:{{ $root.Values.workloads.express.service.port }}"
+            {{- end }}
+            {{- if or (eq $component "nextjs") (eq $component "nextjsCustom") (eq $component "tanstack") }}
+            {{- with $root.Values.publicBaseUrls.graphql }}
+            - name: PUBLIC_GRAPHQL_BASE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $root.Values.publicBaseUrls.express }}
+            - name: PUBLIC_EXPRESS_BASE_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- if eq $component "express" }}
             - name: SQLITE_PATH

--- a/deploy/helm/obs-playground/templates/ingresses.yaml
+++ b/deploy/helm/obs-playground/templates/ingresses.yaml
@@ -1,0 +1,46 @@
+{{- $root := . -}}
+{{- range $component := list "graphql" "express" "nextjs" "nextjsCustom" "tanstack" }}
+{{- $workload := index $root.Values.workloads $component }}
+{{- if $workload.ingress.enabled }}
+{{- if not $workload.ingress.hosts }}{{ fail (printf "workloads.%s.ingress.hosts must contain at least one route when ingress is enabled" $component) }}{{ end }}
+{{- range $host := $workload.ingress.hosts }}
+{{- if not $host.paths }}{{ fail (printf "every workloads.%s.ingress.hosts entry must contain at least one path" $component) }}{{ end }}
+{{- end }}
+{{- $context := dict "root" $root "component" $component }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "obs-playground.workloadName" $context }}
+  labels:
+    {{- include "obs-playground.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ include "obs-playground.componentName" $component }}
+  {{- with $workload.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $workload.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $workload.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $host := $workload.ingress.hosts }}
+    - host: {{ $host.host | quote }}
+      http:
+        paths:
+          {{- range $host.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "obs-playground.workloadName" $context }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/deploy/helm/obs-playground/templates/pvc.yaml
+++ b/deploy/helm/obs-playground/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.persistence.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "obs-playground.expressClaimName" . }}
+  labels:
+    {{- include "obs-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: express
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.capacity }}
+{{- end }}

--- a/deploy/helm/obs-playground/templates/services.yaml
+++ b/deploy/helm/obs-playground/templates/services.yaml
@@ -1,0 +1,22 @@
+{{- $root := . -}}
+{{- range $component := list "graphql" "express" "nextjs" "nextjsCustom" "tanstack" }}
+{{- $workload := index $root.Values.workloads $component }}
+{{- $context := dict "root" $root "component" $component }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obs-playground.workloadName" $context }}
+  labels:
+    {{- include "obs-playground.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ include "obs-playground.componentName" $component }}
+spec:
+  type: {{ $workload.service.type }}
+  ports:
+    - name: http
+      port: {{ $workload.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "obs-playground.selectorLabels" $context | nindent 4 }}
+---
+{{- end }}

--- a/deploy/helm/obs-playground/tests/representative-values.yaml
+++ b/deploy/helm/obs-playground/tests/representative-values.yaml
@@ -3,6 +3,10 @@ global:
     - name: EXAMPLE_RUNTIME_SETTING
       value: global-default
 
+publicBaseUrls:
+  graphql: https://graphql.example.test
+  express: https://express.example.test
+
 datadog:
   otlpProtocol: grpc
   otlpEndpoint: http://datadog-agent.monitoring.svc.cluster.local:4317

--- a/deploy/helm/obs-playground/tests/representative-values.yaml
+++ b/deploy/helm/obs-playground/tests/representative-values.yaml
@@ -1,0 +1,63 @@
+global:
+  env:
+    - name: EXAMPLE_RUNTIME_SETTING
+      value: global-default
+
+datadog:
+  otlpProtocol: grpc
+  otlpEndpoint: http://datadog-agent.monitoring.svc.cluster.local:4317
+
+persistence:
+  storageClass: test-storage
+  capacity: 2Gi
+
+workloads:
+  graphql:
+    replicaCount: 2
+    service:
+      port: 80
+    ingress:
+      enabled: true
+      hosts:
+        - host: graphql.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+  express:
+    env:
+      - name: EXAMPLE_RUNTIME_SETTING
+        value: configured-at-runtime
+    ingress:
+      enabled: true
+      hosts:
+        - host: express.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+  nextjs:
+    replicaCount: 3
+    ingress:
+      enabled: true
+      hosts:
+        - host: nextjs.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+  nextjsCustom:
+    replicaCount: 4
+    ingress:
+      enabled: true
+      hosts:
+        - host: nextjs-custom.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+  tanstack:
+    replicaCount: 5
+    ingress:
+      enabled: true
+      hosts:
+        - host: tanstack.example.test
+          paths:
+            - path: /
+              pathType: Prefix

--- a/deploy/helm/obs-playground/tests/template-test.sh
+++ b/deploy/helm/obs-playground/tests/template-test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for command in helm kubeconform yq; do
+  command -v "${command}" >/dev/null || {
+    printf 'Required command not found: %s\n' "${command}" >&2
+    exit 1
+  }
+done
+
+chart_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+values_file="${chart_dir}/tests/representative-values.yaml"
+rendered=$(mktemp)
+rendered_json=$(mktemp)
+trap 'rm -f "${rendered}" "${rendered_json}"' EXIT
+
+helm lint "${chart_dir}"
+helm template test "${chart_dir}" --values "${values_file}" > "${rendered}"
+kubeconform -strict -summary < "${rendered}"
+yq eval-all -o=json -I=0 '.' "${rendered}" > "${rendered_json}"
+
+python3 - "${rendered_json}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+objects = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines()]
+resources = {(obj["kind"], obj["metadata"]["name"]): obj for obj in objects}
+
+def resource(kind, name):
+    value = resources.get((kind, name))
+    assert value is not None, f"missing {kind}/{name}"
+    return value
+
+prefix = "test-obs-playground"
+components = ["graphql", "express", "nextjs", "nextjs-custom", "tanstack"]
+assert sum(obj["kind"] == "Deployment" for obj in objects) == 5
+assert sum(obj["kind"] == "Service" for obj in objects) == 5
+assert sum(obj["kind"] == "Ingress" for obj in objects) == 5
+
+expected_replicas = {"graphql": 2, "express": 1, "nextjs": 3, "nextjs-custom": 4, "tanstack": 5}
+expected_container_ports = {"graphql": 4000, "express": 3001, "nextjs": 3000, "nextjs-custom": 3000, "tanstack": 3000}
+expected_service_ports = {**expected_container_ports, "graphql": 80}
+expected_images = {component: f"ghcr.io/eli0shin/obs-playground-{component}:0.1.0" for component in components}
+
+def deployment_details(component):
+    deployment = resource("Deployment", f"{prefix}-{component}")
+    spec = deployment["spec"]
+    pod_spec = spec["template"]["spec"]
+    assert len(pod_spec["containers"]) == 1
+    container = pod_spec["containers"][0]
+    env_entries = container["env"]
+    env_names = [entry["name"] for entry in env_entries]
+    assert len(env_names) == len(set(env_names)), f"duplicate environment name in {component}"
+    return deployment, spec, pod_spec, container, {entry["name"]: entry.get("value") for entry in env_entries}
+
+for component in components:
+    name = f"{prefix}-{component}"
+    _, spec, _, container, env = deployment_details(component)
+    assert spec["replicas"] == expected_replicas[component]
+    assert spec["strategy"]["type"] == ("Recreate" if component == "express" else "RollingUpdate")
+    assert container["image"] == expected_images[component]
+    assert container["ports"] == [{"name": "http", "containerPort": expected_container_ports[component], "protocol": "TCP"}]
+    assert env["PORT"] == str(expected_container_ports[component])
+    assert env["DATADOG_OTLP_PROTOCOL"] == "grpc"
+    assert env["DATADOG_OTLP_ENDPOINT"] == "http://datadog-agent.monitoring.svc.cluster.local:4317"
+    assert container["readinessProbe"]["httpGet"] == {"path": "/health", "port": "http"}
+    assert container["livenessProbe"]["httpGet"] == {"path": "/health", "port": "http"}
+    assert set(container["resources"]) == {"requests", "limits"}
+
+    service = resource("Service", name)
+    assert service["spec"]["selector"] == spec["selector"]["matchLabels"]
+    assert service["spec"]["ports"] == [{"name": "http", "port": expected_service_ports[component], "targetPort": "http", "protocol": "TCP"}]
+
+    ingress = resource("Ingress", name)
+    rule = ingress["spec"]["rules"][0]
+    assert rule["host"] == f"{component}.example.test"
+    assert rule["http"]["paths"][0]["backend"]["service"] == {"name": name, "port": {"name": "http"}}
+
+_, _, express_pod, _, express_env = deployment_details("express")
+assert express_env["SQLITE_PATH"] == "/var/data/app.db"
+assert express_env["EXAMPLE_RUNTIME_SETTING"] == "configured-at-runtime"
+assert express_pod["volumes"] == [{"name": "data", "persistentVolumeClaim": {"claimName": f"{prefix}-express-data"}}]
+express_container = express_pod["containers"][0]
+assert express_container["volumeMounts"] == [{"name": "data", "mountPath": "/var/data"}]
+
+pvc = resource("PersistentVolumeClaim", f"{prefix}-express-data")
+assert pvc["spec"]["storageClassName"] == "test-storage"
+assert pvc["spec"]["resources"]["requests"]["storage"] == "2Gi"
+
+_, _, _, _, graphql_env = deployment_details("graphql")
+assert graphql_env["EXPRESS_BASE_URL"] == f"http://{prefix}-express:3001"
+for component in ["express", "nextjs", "nextjs-custom", "tanstack"]:
+    _, _, _, _, env = deployment_details(component)
+    assert env["GRAPHQL_BASE_URL"] == f"http://{prefix}-graphql:80"
+for component in ["nextjs", "nextjs-custom", "tanstack"]:
+    _, _, _, _, env = deployment_details(component)
+    assert env["EXPRESS_BASE_URL"] == f"http://{prefix}-express:3001"
+PY
+
+if helm template test "${chart_dir}" --set workloads.graphql.ingress.enabled=true >/dev/null 2>&1; then
+  echo "enabled ingress without hosts unexpectedly rendered" >&2
+  exit 1
+fi
+
+if helm template test "${chart_dir}" \
+  --set workloads.graphql.ingress.enabled=true \
+  --set workloads.graphql.ingress.hosts[0].host=graphql.example.test >/dev/null 2>&1; then
+  echo "enabled ingress without paths unexpectedly rendered" >&2
+  exit 1
+fi

--- a/deploy/helm/obs-playground/tests/template-test.sh
+++ b/deploy/helm/obs-playground/tests/template-test.sh
@@ -78,6 +78,7 @@ for component in components:
     assert rule["http"]["paths"][0]["backend"]["service"] == {"name": name, "port": {"name": "http"}}
 
 _, _, express_pod, _, express_env = deployment_details("express")
+assert express_pod["securityContext"] == {"fsGroup": 1000, "fsGroupChangePolicy": "OnRootMismatch"}
 assert express_env["SQLITE_PATH"] == "/var/data/app.db"
 assert express_env["EXAMPLE_RUNTIME_SETTING"] == "configured-at-runtime"
 assert express_pod["volumes"] == [{"name": "data", "persistentVolumeClaim": {"claimName": f"{prefix}-express-data"}}]
@@ -96,6 +97,8 @@ for component in ["express", "nextjs", "nextjs-custom", "tanstack"]:
 for component in ["nextjs", "nextjs-custom", "tanstack"]:
     _, _, _, _, env = deployment_details(component)
     assert env["EXPRESS_BASE_URL"] == f"http://{prefix}-express:3001"
+    assert env["PUBLIC_GRAPHQL_BASE_URL"] == "https://graphql.example.test"
+    assert env["PUBLIC_EXPRESS_BASE_URL"] == "https://express.example.test"
 PY
 
 if helm template test "${chart_dir}" --set workloads.graphql.ingress.enabled=true >/dev/null 2>&1; then

--- a/deploy/helm/obs-playground/tests/template-test.sh
+++ b/deploy/helm/obs-playground/tests/template-test.sh
@@ -12,14 +12,21 @@ chart_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 values_file="${chart_dir}/tests/representative-values.yaml"
 rendered=$(mktemp)
 rendered_json=$(mktemp)
-trap 'rm -f "${rendered}" "${rendered_json}"' EXIT
+long_rendered=$(mktemp)
+long_rendered_json=$(mktemp)
+trap 'rm -f "${rendered}" "${rendered_json}" "${long_rendered}" "${long_rendered_json}"' EXIT
 
 helm lint "${chart_dir}"
 helm template test "${chart_dir}" --values "${values_file}" > "${rendered}"
 kubeconform -strict -summary < "${rendered}"
 yq eval-all -o=json -I=0 '.' "${rendered}" > "${rendered_json}"
 
-python3 - "${rendered_json}" <<'PY'
+long_release=$(printf 'r%.0s' {1..50})
+helm template "${long_release}" "${chart_dir}" > "${long_rendered}"
+kubeconform -strict -summary < "${long_rendered}"
+yq eval-all -o=json -I=0 '.' "${long_rendered}" > "${long_rendered_json}"
+
+python3 - "${rendered_json}" "${long_rendered_json}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -99,6 +106,18 @@ for component in ["nextjs", "nextjs-custom", "tanstack"]:
     assert env["EXPRESS_BASE_URL"] == f"http://{prefix}-express:3001"
     assert env["PUBLIC_GRAPHQL_BASE_URL"] == "https://graphql.example.test"
     assert env["PUBLIC_EXPRESS_BASE_URL"] == "https://express.example.test"
+
+long_objects = [json.loads(line) for line in Path(sys.argv[2]).read_text().splitlines()]
+for kind in ["Deployment", "Service"]:
+    names = [obj["metadata"]["name"] for obj in long_objects if obj["kind"] == kind]
+    assert len(names) == len(set(names)) == 5
+    for component in components:
+        assert sum(name.endswith(f"-{component}") for name in names) == 1
+    assert all(len(name) <= 63 for name in names)
+
+long_pvc = next(obj for obj in long_objects if obj["kind"] == "PersistentVolumeClaim")
+assert long_pvc["metadata"]["name"].endswith("-express-data")
+assert len(long_pvc["metadata"]["name"]) <= 63
 PY
 
 if helm template test "${chart_dir}" --set workloads.graphql.ingress.enabled=true >/dev/null 2>&1; then

--- a/deploy/helm/obs-playground/values.yaml
+++ b/deploy/helm/obs-playground/values.yaml
@@ -6,6 +6,12 @@ imagePullSecrets: []
 global:
   env: []
 
+# Browser-reachable backend URLs injected into frontend pages at runtime.
+# Keep these separate from the cluster-local URLs used by server-side requests.
+publicBaseUrls:
+  graphql: ""
+  express: ""
+
 datadog:
   otlpProtocol: grpc
   # Leave empty to disable the Datadog exporter. For example:

--- a/deploy/helm/obs-playground/values.yaml
+++ b/deploy/helm/obs-playground/values.yaml
@@ -1,0 +1,143 @@
+nameOverride: ""
+fullnameOverride: ""
+imagePullSecrets: []
+
+# These variables are added to every service. Use secretKeyRef entries for secrets.
+global:
+  env: []
+
+datadog:
+  otlpProtocol: grpc
+  # Leave empty to disable the Datadog exporter. For example:
+  # http://datadog-agent.datadog.svc.cluster.local:4317
+  otlpEndpoint: ""
+
+persistence:
+  storageClass: ""
+  capacity: 1Gi
+  existingClaim: ""
+
+workloads:
+  graphql:
+    replicaCount: 1
+    containerPort: 4000
+    image:
+      repository: ghcr.io/eli0shin/obs-playground-graphql
+      tag: ""
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 4000
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    env: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+
+  express:
+    containerPort: 3001
+    image:
+      repository: ghcr.io/eli0shin/obs-playground-express
+      tag: ""
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3001
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    env: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+
+  nextjs:
+    replicaCount: 1
+    containerPort: 3000
+    image:
+      repository: ghcr.io/eli0shin/obs-playground-nextjs
+      tag: ""
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3000
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    env: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+
+  nextjsCustom:
+    replicaCount: 1
+    containerPort: 3000
+    image:
+      repository: ghcr.io/eli0shin/obs-playground-nextjs-custom
+      tag: ""
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3000
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    env: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []
+
+  tanstack:
+    replicaCount: 1
+    containerPort: 3000
+    image:
+      repository: ghcr.io/eli0shin/obs-playground-tanstack
+      tag: ""
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 3000
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    env: []
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts: []
+      tls: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -21091,7 +21091,8 @@
         "@types/node": "^20",
         "eslint": "^9.38.0",
         "typescript": "^5",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.0.6"
       }
     },
     "packages/env/node_modules/@types/node": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -15,12 +15,14 @@
     "build": "tsc",
     "dev": "tsc --watch --preserveWatchOutput",
     "type-check": "tsc --noEmit",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest --run --exclude 'dist/**'"
   },
   "devDependencies": {
     "@types/node": "^20",
     "eslint": "^9.38.0",
     "typescript": "^5",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.0.6"
   }
 }

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getExpressUrl, getGraphqlUrl, getRuntimeEnv } from "./index.js";
+
+const ENV_KEYS = [
+  "EXPRESS_BASE_URL",
+  "GRAPHQL_BASE_URL",
+  "IS_PULL_REQUEST",
+  "PUBLIC_EXPRESS_BASE_URL",
+  "PUBLIC_GRAPHQL_BASE_URL",
+  "RENDER_EXTERNAL_URL",
+] as const;
+
+beforeEach(() => {
+  globalThis.__ENV = undefined;
+  for (const key of ENV_KEYS) vi.stubEnv(key, undefined);
+});
+
+afterEach(() => {
+  globalThis.__ENV = undefined;
+  vi.unstubAllEnvs();
+});
+
+describe("runtime environment URLs", () => {
+  it("injects public URLs while server URL helpers retain internal URLs", () => {
+    vi.stubEnv("GRAPHQL_BASE_URL", "http://graphql:4000");
+    vi.stubEnv("EXPRESS_BASE_URL", "http://express:3001");
+    vi.stubEnv("PUBLIC_GRAPHQL_BASE_URL", "https://graphql.example.test");
+    vi.stubEnv("PUBLIC_EXPRESS_BASE_URL", "https://express.example.test");
+
+    expect(getRuntimeEnv()).toEqual({
+      GRAPHQL_BASE_URL: "https://graphql.example.test",
+      EXPRESS_BASE_URL: "https://express.example.test",
+    });
+    expect(getGraphqlUrl()).toBe("http://graphql:4000/graphql");
+    expect(getExpressUrl()).toBe("http://express:3001");
+  });
+
+  it("falls back to server URLs when public URLs are not configured", () => {
+    vi.stubEnv("GRAPHQL_BASE_URL", "http://graphql:4000");
+    vi.stubEnv("EXPRESS_BASE_URL", "http://express:3001");
+
+    expect(getRuntimeEnv()).toEqual({
+      GRAPHQL_BASE_URL: "http://graphql:4000",
+      EXPRESS_BASE_URL: "http://express:3001",
+    });
+  });
+
+  it("preserves Render pull request URL derivation", () => {
+    vi.stubEnv("IS_PULL_REQUEST", "true");
+    vi.stubEnv("RENDER_EXTERNAL_URL", "https://obs-nextjs-pr-42.onrender.com");
+
+    expect(getRuntimeEnv()).toEqual({
+      GRAPHQL_BASE_URL: "https://obs-graphql-pr-42.onrender.com",
+      EXPRESS_BASE_URL: "https://obs-express-pr-42.onrender.com",
+    });
+    expect(getGraphqlUrl()).toBe(
+      "https://obs-graphql-pr-42.onrender.com/graphql",
+    );
+    expect(getExpressUrl()).toBe("https://obs-express-pr-42.onrender.com");
+  });
+});

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -39,10 +39,15 @@ function getEnv(key: keyof RuntimeEnv): string | undefined {
   return process.env[key];
 }
 
+function getPublicEnv(key: keyof RuntimeEnv): string | undefined {
+  if (typeof process === "undefined") return getEnv(key);
+  return process.env[`PUBLIC_${key}`] ?? getEnv(key);
+}
+
 export function getRuntimeEnv(): RuntimeEnv {
   return {
-    GRAPHQL_BASE_URL: getEnv("GRAPHQL_BASE_URL"),
-    EXPRESS_BASE_URL: getEnv("EXPRESS_BASE_URL"),
+    GRAPHQL_BASE_URL: getPublicEnv("GRAPHQL_BASE_URL"),
+    EXPRESS_BASE_URL: getPublicEnv("EXPRESS_BASE_URL"),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a portable OCI-ready Helm chart for GraphQL, Express, standard Next.js, custom-server Next.js, and TanStack Start using the dedicated GHCR image repositories.
- Model internal service discovery, health probes, runtime OpenTelemetry configuration, configurable resources and replicas, and five independent ingresses without embedding cluster-specific hostnames, credentials, authentication, or a Datadog Agent.
- Preserve Express's single-replica `Recreate` contract with configurable persistent SQLite storage at `/var/data/app.db`.
- Add chart validation CI with representative rendering, strict Kubernetes schema validation, and structural assertions across all workloads.

## Verification
- Representative Helm rendering produces five Deployments, five Services, five independently routed Ingresses, and the Express PVC; strict kubeconform validation accepts all 16 resources.
- Structural checks verify image repositories, replica/update strategies, service-derived runtime URLs, gRPC Datadog endpoint configuration, health probes, resource settings, ingress backends, and workload-over-global environment overrides without duplicate variables.
- Negative rendering checks reject enabled ingresses that omit hosts or paths.

<!-- pi-orchestration-run: 8e9bfb61-0701-4c00-af07-45ca22520c6f -->
