### PR TITLE
Publish patch releases to GHCR

### DIFF
--- a/.github/workflows/express-container.yml
+++ b/.github/workflows/express-container.yml
@@ -3,32 +3,6 @@ name: Express Container
 on:
   pull_request:
     branches: [main, create-hemlchart]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/express-container.yml"
-      - "apps/express-server/**"
-      - "deploy/docker/express/**"
-      - "packages/env/**"
-      - "packages/graphql-client/**"
-      - "packages/otel/**"
-      - "patches/**"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
-  push:
-    branches: [main]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/express-container.yml"
-      - "apps/express-server/**"
-      - "deploy/docker/express/**"
-      - "packages/env/**"
-      - "packages/graphql-client/**"
-      - "packages/otel/**"
-      - "patches/**"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
 
 permissions:
   contents: read

--- a/.github/workflows/graphql-container.yml
+++ b/.github/workflows/graphql-container.yml
@@ -3,30 +3,6 @@ name: GraphQL Container
 on:
   pull_request:
     branches: [main, create-hemlchart]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/graphql-container.yml"
-      - "apps/graphql-server/**"
-      - "deploy/docker/graphql/**"
-      - "packages/env/**"
-      - "packages/otel/**"
-      - "patches/**"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
-  push:
-    branches: [main]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/graphql-container.yml"
-      - "apps/graphql-server/**"
-      - "deploy/docker/graphql/**"
-      - "packages/env/**"
-      - "packages/otel/**"
-      - "patches/**"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
 
 permissions:
   contents: read

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -3,14 +3,6 @@ name: Helm Chart
 on:
   pull_request:
     branches: [main, create-hemlchart]
-    paths:
-      - ".github/workflows/helm-chart.yml"
-      - "deploy/helm/**"
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/helm-chart.yml"
-      - "deploy/helm/**"
 
 permissions:
   contents: read

--- a/.github/workflows/nextjs-containers.yml
+++ b/.github/workflows/nextjs-containers.yml
@@ -3,38 +3,6 @@ name: Next.js Containers
 on:
   pull_request:
     branches: [main, create-hemlchart]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/nextjs-containers.yml"
-      - "apps/nextjs-app/**"
-      - "deploy/docker/nextjs/**"
-      - "deploy/docker/nextjs-custom/**"
-      - "packages/env/**"
-      - "packages/graphql-client/**"
-      - "packages/otel/**"
-      - "packages/trpc-otel/**"
-      - "patches/**"
-      - "scripts/smoke-nextjs-containers.sh"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
-  push:
-    branches: [main]
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/nextjs-containers.yml"
-      - "apps/nextjs-app/**"
-      - "deploy/docker/nextjs/**"
-      - "deploy/docker/nextjs-custom/**"
-      - "packages/env/**"
-      - "packages/graphql-client/**"
-      - "packages/otel/**"
-      - "packages/trpc-otel/**"
-      - "patches/**"
-      - "scripts/smoke-nextjs-containers.sh"
-      - "package.json"
-      - "package-lock.json"
-      - "turbo.json"
 
 permissions:
   contents: read

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,20 +4,82 @@ on:
   push:
     branches: [main]
 
-permissions:
-  actions: read
-  contents: write
-  packages: write
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: eli0shin
   CHART_PATH: deploy/helm/obs-playground
 
 jobs:
+  validate-images:
+    name: Validate ${{ matrix.name }} image${{ matrix.plural }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: GraphQL
+            command: deploy/docker/graphql/smoke-test.sh
+            plural: ""
+          - name: Express
+            command: deploy/docker/express/smoke-test.sh
+            plural: ""
+          - name: Next.js
+            command: scripts/smoke-nextjs-containers.sh
+            plural: s
+          - name: TanStack
+            command: deploy/docker/tanstack/smoke-test.sh
+            plural: ""
+
+    steps:
+      - name: Checkout exact main revision
+        uses: actions/checkout@v4
+
+      - name: Build and smoke test
+        run: ${{ matrix.command }}
+
+  validate-chart:
+    name: Validate Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout exact main revision
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.18.4
+
+      - name: Install chart test tools
+        env:
+          KUBECONFORM_VERSION: v0.7.0
+          YQ_VERSION: v4.45.4
+        run: |
+          curl --fail --silent --show-error --location \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar --extract --gzip --directory /usr/local/bin kubeconform
+          sudo curl --fail --silent --show-error --location \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            --output /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Lint and render chart
+        run: ${{ env.CHART_PATH }}/tests/template-test.sh
+
   version:
     name: Allocate patch version
+    needs:
+      - validate-images
+      - validate-chart
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     outputs:
       version: ${{ steps.next-version.outputs.version }}
       tag: ${{ steps.next-version.outputs.tag }}
@@ -61,6 +123,9 @@ jobs:
     name: Publish ${{ matrix.name }} image
     needs: version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -75,17 +140,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -101,9 +166,12 @@ jobs:
     name: Publish ${{ matrix.name }} image
     needs: version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
-      DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
-      DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
+      DATADOG_APP_ID: ${{ vars.DATADOG_APP_ID }}
+      DATADOG_CLIENT_TOKEN: ${{ vars.DATADOG_CLIENT_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -119,18 +187,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Require frontend build configuration
+        shell: bash
+        run: |
+          test -n "$DATADOG_APP_ID"
+          test -n "$DATADOG_CLIENT_TOKEN"
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -149,13 +223,16 @@ jobs:
     name: Publish Helm chart
     needs: version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.4
 
@@ -178,6 +255,8 @@ jobs:
 
   create-release:
     name: Create GitHub release
+    permissions:
+      contents: write
     needs:
       - version
       - publish-backend-images

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,198 @@
+name: Publish Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: eli0shin
+  CHART_PATH: deploy/helm/obs-playground
+
+jobs:
+  version:
+    name: Allocate patch version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.next-version.outputs.version }}
+      tag: ${{ steps.next-version.outputs.tag }}
+
+    steps:
+      # Unlike Actions concurrency groups, Turnstyle retains every queued run.
+      - name: Wait for earlier release runs
+        uses: softprops/turnstyle@afaccda0f3c0136fb7cb4a734b9b96be03599948 # v3.3.2
+        with:
+          initial-wait-seconds: 60
+          poll-interval-seconds: 20
+
+      - name: Checkout code and release tags
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate next patch version
+        id: next-version
+        shell: bash
+        run: |
+          latest_tag=$(
+            git tag --list \
+              | grep --extended-regexp '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort --version-sort \
+              | tail --lines 1 \
+              || true
+          )
+
+          if [[ -z "$latest_tag" ]]; then
+            version=1.0.1
+          else
+            IFS=. read -r major minor patch <<< "${latest_tag#v}"
+            version="$((10#$major)).$((10#$minor)).$((10#$patch + 1))"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+  publish-backend-images:
+    name: Publish ${{ matrix.name }} image
+    needs: version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: graphql
+            dockerfile: deploy/docker/graphql/Dockerfile
+          - name: express
+            dockerfile: deploy/docker/express/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/obs-playground-${{ matrix.name }}:${{ needs.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+
+  publish-frontend-images:
+    name: Publish ${{ matrix.name }} image
+    needs: version
+    runs-on: ubuntu-latest
+    env:
+      DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+      DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: nextjs
+            dockerfile: deploy/docker/nextjs/Dockerfile
+          - name: nextjs-custom
+            dockerfile: deploy/docker/nextjs-custom/Dockerfile
+          - name: tanstack
+            dockerfile: deploy/docker/tanstack/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/obs-playground-${{ matrix.name }}:${{ needs.version.outputs.version }}
+          build-args: |
+            DATADOG_APP_ID=${{ env.DATADOG_APP_ID }}
+            DATADOG_CLIENT_TOKEN=${{ env.DATADOG_CLIENT_TOKEN }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+
+  publish-chart:
+    name: Publish Helm chart
+    needs: version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          HELM_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$HELM_PASSWORD" | helm registry login "${{ env.REGISTRY }}" --username "${{ github.actor }}" --password-stdin
+
+      - name: Package and publish chart
+        shell: bash
+        run: |
+          helm package "${{ env.CHART_PATH }}" \
+            --destination "$RUNNER_TEMP" \
+            --version "${{ needs.version.outputs.version }}" \
+            --app-version "${{ needs.version.outputs.version }}"
+          helm push \
+            "$RUNNER_TEMP/obs-playground-${{ needs.version.outputs.version }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/charts"
+
+  create-release:
+    name: Create GitHub release
+    needs:
+      - version
+      - publish-backend-images
+      - publish-frontend-images
+      - publish-chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create release tag and GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.version.outputs.tag }}
+        run: >-
+          gh release create "$RELEASE_TAG"
+          --repo "${{ github.repository }}"
+          --target "${{ github.sha }}"
+          --title "$RELEASE_TAG"
+          --generate-notes

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -170,8 +170,8 @@ jobs:
       contents: read
       packages: write
     env:
-      DATADOG_APP_ID: ${{ vars.DATADOG_APP_ID }}
-      DATADOG_CLIENT_TOKEN: ${{ vars.DATADOG_CLIENT_TOKEN }}
+      DATADOG_APP_ID: ${{ secrets.DATADOG_APP_ID }}
+      DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Publish one shared patch release after every push to `main`, beginning at `v1.0.1` and deriving later versions from release tags without changing files on `main`.
- Queue every release run before version allocation, then publish five dedicated `linux/amd64` images and the OCI Helm chart to the agreed GHCR repositories before creating the Git tag and GitHub release.
- Bake GitHub Actions Datadog credentials into all three frontend images through the existing Docker build arguments while leaving runtime frontend and Render configuration unchanged.
- Run every container smoke workflow and Helm lint/render validation on every pull request to the supported target branches.

## Verification
- Actionlint validates the complete workflow graph and all GitHub expressions, including the serialized release dependencies and release-after-publication gate.
- Existing image-level pull-request checks build and smoke test all five production containers; chart validation lints and renders representative values with strict Kubernetes schema and structural assertions.
- GHCR publication and GitHub release creation can only execute from a push to `main`, so those external writes remain intentionally unexercised by this pull request.

<!-- pi-orchestration-run: 9f1a9726-3dbc-40b1-9f0c-bfd3489eab3b -->
