### PR TITLE
Prevent slow container startup probe restart loops

### DIFF
--- a/deploy/helm/obs-playground/README.md
+++ b/deploy/helm/obs-playground/README.md
@@ -12,6 +12,22 @@ Express always runs one replica with the `Recreate` strategy and mounts its PVC 
 
 Each ingress is disabled by default and can be configured independently under `workloads.<service>.ingress`. Browser-visible `NEXT_PUBLIC_*` and `VITE_*` settings are compiled into the frontend images and must be supplied when those images are built; Helm values configure the server runtimes.
 
+## Health probes
+
+All five workloads use `/health` for startup, readiness, and liveness checks. Kubernetes does not run readiness or liveness checks until the startup probe succeeds, preventing slower services from being restarted before they begin listening. Configure the shared startup-probe contract under `probes.startup`:
+
+```yaml
+probes:
+  startup:
+    path: /health
+    port: http
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 30
+```
+
+The startup window is `periodSeconds * failureThreshold`; the default allows 150 seconds. Keep `port` set to the named HTTP container port unless you also adapt the workload ports.
+
 ## Validation
 
 The representative test requires Helm, kubeconform, yq v4, and Python 3.

--- a/deploy/helm/obs-playground/templates/deployments.yaml
+++ b/deploy/helm/obs-playground/templates/deployments.yaml
@@ -81,6 +81,13 @@ spec:
             - name: http
               containerPort: {{ $workload.containerPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: {{ $root.Values.probes.startup.path }}
+              port: {{ $root.Values.probes.startup.port }}
+            periodSeconds: {{ $root.Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ $root.Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ $root.Values.probes.startup.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /health

--- a/deploy/helm/obs-playground/tests/representative-values.yaml
+++ b/deploy/helm/obs-playground/tests/representative-values.yaml
@@ -15,6 +15,15 @@ persistence:
   storageClass: test-storage
   capacity: 2Gi
 
+# Representative timings for telemetry-heavy startup on the homelab.
+probes:
+  startup:
+    path: /health
+    port: http
+    periodSeconds: 6
+    timeoutSeconds: 3
+    failureThreshold: 25
+
 workloads:
   graphql:
     replicaCount: 2

--- a/deploy/helm/obs-playground/tests/template-test.sh
+++ b/deploy/helm/obs-playground/tests/template-test.sh
@@ -71,6 +71,12 @@ for component in components:
     assert env["PORT"] == str(expected_container_ports[component])
     assert env["DATADOG_OTLP_PROTOCOL"] == "grpc"
     assert env["DATADOG_OTLP_ENDPOINT"] == "http://datadog-agent.monitoring.svc.cluster.local:4317"
+    assert container["startupProbe"] == {
+        "httpGet": {"path": "/health", "port": "http"},
+        "periodSeconds": 6,
+        "timeoutSeconds": 3,
+        "failureThreshold": 25,
+    }
     assert container["readinessProbe"]["httpGet"] == {"path": "/health", "port": "http"}
     assert container["livenessProbe"]["httpGet"] == {"path": "/health", "port": "http"}
     assert set(container["resources"]) == {"requests", "limits"}

--- a/deploy/helm/obs-playground/tests/template-test.sh
+++ b/deploy/helm/obs-playground/tests/template-test.sh
@@ -114,6 +114,17 @@ for component in ["nextjs", "nextjs-custom", "tanstack"]:
     assert env["PUBLIC_EXPRESS_BASE_URL"] == "https://express.example.test"
 
 long_objects = [json.loads(line) for line in Path(sys.argv[2]).read_text().splitlines()]
+long_deployments = [obj for obj in long_objects if obj["kind"] == "Deployment"]
+assert len(long_deployments) == 5
+for deployment in long_deployments:
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["startupProbe"] == {
+        "httpGet": {"path": "/health", "port": "http"},
+        "periodSeconds": 5,
+        "timeoutSeconds": 2,
+        "failureThreshold": 30,
+    }
+
 for kind in ["Deployment", "Service"]:
     names = [obj["metadata"]["name"] for obj in long_objects if obj["kind"] == kind]
     assert len(names) == len(set(names)) == 5

--- a/deploy/helm/obs-playground/values.yaml
+++ b/deploy/helm/obs-playground/values.yaml
@@ -23,6 +23,16 @@ persistence:
   capacity: 1Gi
   existingClaim: ""
 
+# Startup probes delay readiness and liveness checks until each service is listening.
+# The default 150-second window accommodates telemetry initialization on slower hosts.
+probes:
+  startup:
+    path: /health
+    port: http
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 30
+
 workloads:
   graphql:
     replicaCount: 1


### PR DESCRIPTION
## Summary
- Add a shared HTTP startup-probe contract to all five Helm workloads so Kubernetes defers readiness and liveness checks until each service begins listening.
- Default the startup window to 150 seconds for telemetry-heavy startup on slower homelab hosts while preserving the existing `/health` readiness and liveness probes.
- Document the values interface and extend representative chart assertions across every Deployment.

## Verification
- Representative Helm rendering confirms all five Deployments receive the configured `/health` startup probe and homelab timing values.
- Strict Kubernetes schema validation accepts both representative and default chart renders.
- Publishing the patch release, Flux adoption, and live endpoint/telemetry recovery remain post-merge verification because those external workflows only run from `main`.

<!-- pi-orchestration-run: 9f1a9726-3dbc-40b1-9f0c-bfd3489eab3b -->
